### PR TITLE
add stats-bind-any -a option

### DIFF
--- a/src/nc.c
+++ b/src/nc.c
@@ -34,7 +34,10 @@
 #define NC_LOG_MAX          LOG_PVERB
 #define NC_LOG_PATH         NULL
 
-#define NC_STATS_PORT       STATS_PORT
+#define NC_STATS_DEFAULT_PORT       STATS_DEFAULT_PORT
+#define NC_STATS_DEFAULT_ADDR       STATS_DEFAULT_ADDR
+#define NC_STATS_ANY_ADDR           STATS_ANY_ADDR
+
 #define NC_STATS_INTERVAL   STATS_INTERVAL
 
 #define NC_PID_FILE         NULL
@@ -60,12 +63,13 @@ static struct option long_options[] = {
     { "conf-file",      required_argument,  NULL,   'c' },
     { "stats-port",     required_argument,  NULL,   's' },
     { "stats-interval", required_argument,  NULL,   'i' },
+    { "stats-bind-any", no_argument,        NULL,   'a' },
     { "pid-file",       required_argument,  NULL,   'p' },
     { "mbuf-size",      required_argument,  NULL,   'm' },
     { NULL,             0,                  NULL,    0  }
 };
 
-static char short_options[] = "hVtdDv:o:c:s:i:p:m:";
+static char short_options[] = "hVtdDv:o:c:s:i:ap:m:";
 
 static rstatus_t
 nc_daemonize(int dump_core)
@@ -204,12 +208,13 @@ nc_show_usage(void)
         "  -c, --conf-file=S      : set configuration file (default: %s)" CRLF
         "  -s, --stats-port=N     : set stats monitoring port (default: %d)" CRLF
         "  -i, --stats-interval=N : set stats aggregation interval in msec (default: %d msec)" CRLF
+        "  -a, --stats-bind-any   : set stats monitoring ip to INADDR_ANY (default: %s)" CRLF
         "  -p, --pid-file=S       : set pid file (default: %s)" CRLF
         "  -m, --mbuf-size=N      : set size of mbuf chunk in bytes (default: %d bytes)" CRLF
         "",
         NC_LOG_DEFAULT, NC_LOG_MIN, NC_LOG_MAX,
         NC_LOG_PATH != NULL ? NC_LOG_PATH : "stderr",
-        NC_CONF_PATH, NC_STATS_PORT, NC_STATS_INTERVAL,
+        NC_CONF_PATH, NC_STATS_DEFAULT_PORT, NC_STATS_INTERVAL, NC_STATS_DEFAULT_ADDR,
         NC_PID_FILE != NULL ? NC_PID_FILE : "off",
         NC_MBUF_SIZE);
 }
@@ -267,7 +272,8 @@ nc_set_default_options(struct instance *nci)
 
     nci->conf_filename = NC_CONF_PATH;
 
-    nci->stats_port = NC_STATS_PORT;
+    nci->stats_port = NC_STATS_DEFAULT_PORT;
+    nci->stats_addr = NC_STATS_DEFAULT_ADDR;
     nci->stats_interval = NC_STATS_INTERVAL;
 
     status = nc_gethostname(nci->hostname, NC_MAXHOSTNAMELEN);
@@ -361,6 +367,10 @@ nc_get_options(int argc, char **argv, struct instance *nci)
             }
 
             nci->stats_interval = value;
+            break;
+
+        case 'a':
+            nci->stats_addr = NC_STATS_ANY_ADDR;
             break;
 
         case 'p':

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -64,7 +64,7 @@ core_ctx_create(struct instance *nci)
     }
 
     /* create stats per server pool */
-    ctx->stats = stats_create(nci->stats_port, nci->stats_interval,
+    ctx->stats = stats_create(nci->stats_port, nci->stats_addr, nci->stats_interval,
                               nci->hostname, &ctx->pool);
     if (ctx->stats == NULL) {
         server_pool_deinit(&ctx->pool);

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -116,6 +116,7 @@ struct instance {
     char            *conf_filename;              /* configuration filename */
     uint16_t        stats_port;                  /* stats monitoring port */
     int             stats_interval;              /* stats aggregation interval */
+    char            *stats_addr;                 /* stats moritoring addr*/
     char            hostname[NC_MAXHOSTNAMELEN]; /* hostname */
     size_t          mbuf_chunk_size;             /* mbuf chunk size */
     pid_t           pid;                         /* process id */

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -826,8 +826,8 @@ stats_listen(struct stats *st)
 
     status = bind(st->sd, (struct sockaddr *)&si.addr, si.addrlen);
     if (status < 0) {
-        log_error("bind on m %d to addr '%s:%u' failed: %s", st->sd,
-                  STATS_ADDR, st->port, strerror(errno));
+        log_error("bind on m %d to addr '%.*s:%u' failed: %s", st->sd,
+                  st->addr.len, st->addr.data, st->port, strerror(errno));
         return NC_ERROR;
     }
 
@@ -837,8 +837,8 @@ stats_listen(struct stats *st)
         return NC_ERROR;
     }
 
-    log_debug(LOG_NOTICE, "m %d listening on '%s:%u'", st->sd, STATS_ADDR,
-              st->port);
+    log_debug(LOG_NOTICE, "m %d listening on '%.*s:%u'", st->sd, 
+                st->addr.len, st->addr.data, st->port);
 
     return NC_OK;
 }
@@ -895,7 +895,7 @@ stats_stop_aggregator(struct stats *st)
 }
 
 struct stats *
-stats_create(uint16_t stats_port, int stats_interval, char *source,
+stats_create(uint16_t stats_port, char *stats_ip, int stats_interval, char *source,
              struct array *server_pool)
 {
     rstatus_t status;
@@ -908,7 +908,7 @@ stats_create(uint16_t stats_port, int stats_interval, char *source,
 
     st->port = stats_port;
     st->interval = stats_interval;
-    string_set_text(&st->addr, STATS_ADDR);
+    string_set_raw(&st->addr, stats_ip);
 
     st->start_ts = (int64_t)time(NULL);
 

--- a/src/nc_stats.h
+++ b/src/nc_stats.h
@@ -49,8 +49,9 @@
     ACTION( out_queue,              STATS_GAUGE,        "# requests in outgoing queue")                     \
     ACTION( out_queue_bytes,        STATS_GAUGE,        "current request bytes in outgoing queue")          \
 
-#define STATS_ADDR      "localhost"
-#define STATS_PORT      22222
+#define STATS_DEFAULT_ADDR      "localhost"
+#define STATS_ANY_ADDR          "0.0.0.0"
+#define STATS_DEFAULT_PORT      22222
 #define STATS_INTERVAL  (30 * 1000) /* in msec */
 
 typedef enum stats_type {
@@ -199,7 +200,7 @@ void _stats_server_decr(struct context *ctx, struct server *server, stats_server
 void _stats_server_incr_by(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
 void _stats_server_decr_by(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
 
-struct stats *stats_create(uint16_t stats_port, int stats_interval, char *source, struct array *server_pool);
+struct stats *stats_create(uint16_t stats_port, char *stats_ip, int stats_interval, char *source, struct array *server_pool);
 void stats_destroy(struct stats *stats);
 void stats_swap(struct stats *stats);
 


### PR DESCRIPTION
twemproxy uses only localhost as monitoring bind ip.

so add -a option to use  INADDR_ANY address;

I considered if someone wants to set ip address later.

at that time, only change the code parsing option -a.

Thank you.
