### PR TITLE
Robust hash ring failure retry mechanism

### DIFF
--- a/src/hashkit/nc_ketama.c
+++ b/src/hashkit/nc_ketama.c
@@ -90,12 +90,8 @@ ketama_update(struct server_pool *pool)
         struct server *server = array_get(&pool->server, server_index);
 
         if (pool->auto_eject_hosts) {
-            if (server->next_retry <= now) {
-                server->next_retry = 0LL;
+            if (server->fail == 0) {
                 nlive_server++;
-            } else if (pool->next_rebuild == 0LL ||
-                       server->next_retry < pool->next_rebuild) {
-                pool->next_rebuild = server->next_retry;
             }
         } else {
             nlive_server++;
@@ -104,7 +100,7 @@ ketama_update(struct server_pool *pool)
         ASSERT(server->weight > 0);
 
         /* count weight only for live servers */
-        if (!pool->auto_eject_hosts || server->next_retry <= now) {
+        if (!pool->auto_eject_hosts || server->fail == 0) {
             total_weight += server->weight;
         }
     }

--- a/src/hashkit/nc_modula.c
+++ b/src/hashkit/nc_modula.c
@@ -51,12 +51,8 @@ modula_update(struct server_pool *pool)
         struct server *server = array_get(&pool->server, server_index);
 
         if (pool->auto_eject_hosts) {
-            if (server->next_retry <= now) {
-                server->next_retry = 0LL;
+            if (server->fail == 0) {
                 nlive_server++;
-            } else if (pool->next_rebuild == 0LL ||
-                       server->next_retry < pool->next_rebuild) {
-                pool->next_rebuild = server->next_retry;
             }
         } else {
             nlive_server++;

--- a/src/hashkit/nc_random.c
+++ b/src/hashkit/nc_random.c
@@ -51,12 +51,8 @@ random_update(struct server_pool *pool)
         struct server *server = array_get(&pool->server, server_index);
 
         if (pool->auto_eject_hosts) {
-            if (server->next_retry <= now) {
-                server->next_retry = 0LL;
+            if (server->fail == 0) {
                 nlive_server++;
-            } else if (pool->next_rebuild == 0LL ||
-                       server->next_retry < pool->next_rebuild) {
-                pool->next_rebuild = server->next_retry;
             }
         } else {
             nlive_server++;

--- a/src/nc_client.c
+++ b/src/nc_client.c
@@ -187,3 +187,8 @@ client_close(struct context *ctx, struct conn *conn)
 
     conn_put(conn);
 }
+
+void
+client_restore(struct context *ctx, struct conn *conn)
+{
+}

--- a/src/nc_client.h
+++ b/src/nc_client.h
@@ -24,5 +24,6 @@ bool client_active(struct conn *conn);
 void client_ref(struct conn *conn, void *owner);
 void client_unref(struct conn *conn);
 void client_close(struct context *ctx, struct conn *conn);
+void client_restore(struct context *ctx, struct conn *conn);
 
 #endif

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -154,6 +154,7 @@ conf_server_each_transform(void *elem, void *data)
 
     s->next_retry = 0LL;
     s->failure_count = 0;
+    s->fail = FAIL_STATUS_NORMAL;
 
     log_debug(LOG_VERB, "transform to server %"PRIu32" '%.*s'",
               s->idx, s->pname.len, s->pname.data);

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -170,6 +170,7 @@ conn_get(void *owner, bool client, bool redis)
 
         conn->close = client_close;
         conn->active = client_active;
+        conn->restore = client_restore;
 
         conn->ref = client_ref;
         conn->unref = client_unref;
@@ -193,6 +194,7 @@ conn_get(void *owner, bool client, bool redis)
 
         conn->close = server_close;
         conn->active = server_active;
+        conn->restore = server_restore;
 
         conn->ref = server_ref;
         conn->unref = server_unref;
@@ -235,6 +237,7 @@ conn_get_proxy(void *owner)
 
     conn->close = proxy_close;
     conn->active = NULL;
+    conn->restore = proxy_restore;
 
     conn->ref = proxy_ref;
     conn->unref = proxy_unref;

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -35,6 +35,7 @@ typedef void (*conn_ref_t)(struct conn *, void *);
 typedef void (*conn_unref_t)(struct conn *);
 
 typedef void (*conn_msgq_t)(struct context *, struct conn *, struct msg *);
+typedef void (*conn_restore_t)(struct context *, struct conn *);
 
 struct conn {
     TAILQ_ENTRY(conn)  conn_tqe;      /* link in server_pool / server / free q */
@@ -58,6 +59,7 @@ struct conn {
     conn_send_done_t   send_done;     /* write done handler */
     conn_close_t       close;         /* close handler */
     conn_active_t      active;        /* active? handler */
+    conn_restore_t     restore;       /* restore handler */
 
     conn_ref_t         ref;           /* connection reference handler */
     conn_unref_t       unref;         /* connection unreference handler */
@@ -95,5 +97,7 @@ ssize_t conn_recv(struct conn *conn, void *buf, size_t size);
 ssize_t conn_sendv(struct conn *conn, struct array *sendv, size_t nsend);
 void conn_init(void);
 void conn_deinit(void);
+
+rstatus_t event_add_out_with_conn(struct context *ctx, struct conn *conn, struct msg *msg);
 
 #endif

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -96,17 +96,20 @@ struct instance;
 #include <nc_connection.h>
 
 struct context {
-    uint32_t           id;          /* unique context id */
-    struct conf        *cf;         /* configuration */
-    struct stats       *stats;      /* stats */
+    uint32_t           id;                  /* unique context id */
+    struct conf        *cf;                 /* configuration */
+    struct stats       *stats;              /* stats */
 
-    struct array       pool;        /* server_pool[] */
+    struct array       pool;                /* server_pool[] */
+    struct array       failed_servers[2];   /* failed servers */
+    struct array       *fails;              /* ref of current fails server */
 
-    int                ep;          /* epoll device */
-    int                nevent;      /* # epoll event */
-    int                max_timeout; /* epoll wait max timeout in msec */
-    int                timeout;     /* epoll wait timeout in msec */
-    struct epoll_event *event;      /* epoll event */
+    int                failed_idx;           /* current idx for failed servers */
+    int                ep;                  /* epoll device */
+    int                nevent;              /* # epoll event */
+    int                max_timeout;         /* epoll wait max timeout in msec */
+    int                timeout;             /* epoll wait timeout in msec */
+    struct epoll_event *event;              /* epoll event */
 };
 
 struct instance {

--- a/src/nc_proxy.c
+++ b/src/nc_proxy.c
@@ -357,3 +357,8 @@ proxy_recv(struct context *ctx, struct conn *conn)
 
     return NC_OK;
 }
+
+void
+proxy_restore(struct context *ctx, struct conn *conn)
+{
+}

--- a/src/nc_proxy.h
+++ b/src/nc_proxy.h
@@ -30,5 +30,6 @@ rstatus_t proxy_each_deinit(void *elem, void *data);
 rstatus_t proxy_init(struct context *ctx);
 void proxy_deinit(struct context *ctx);
 rstatus_t proxy_recv(struct context *ctx, struct conn *conn);
+void proxy_restore(struct context *ctx, struct conn *conn);
 
 #endif

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -480,16 +480,12 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
     }
     ASSERT(!s_conn->client && !s_conn->proxy);
 
-    /* enqueue the message (request) into server inq */
-    if (TAILQ_EMPTY(&s_conn->imsg_q)) {
-        status = event_add_out(ctx->ep, s_conn);
-        if (status != NC_OK) {
-            req_forward_error(ctx, c_conn, msg);
-            s_conn->err = errno;
-            return;
-        }
+    status = event_add_out_with_conn(ctx, s_conn, msg);
+    if (status != NC_OK) {
+        req_forward_error(ctx, c_conn, msg);
+        s_conn->err = errno;
+        return;
     }
-    s_conn->enqueue_inq(ctx, s_conn, msg);
 
     req_forward_stats(ctx, s_conn->owner, msg);
 
@@ -585,4 +581,20 @@ req_send_done(struct context *ctx, struct conn *conn, struct msg *msg)
     } else {
         req_put(msg);
     }
+}
+
+rstatus_t
+event_add_out_with_conn(struct context *ctx, struct conn *conn, struct msg *msg)
+{
+    rstatus_t status;
+
+    if (TAILQ_EMPTY(&conn->imsg_q)) {
+        status = event_add_out(ctx->ep, conn);
+        if (status != NC_OK) {
+            return status;
+        }
+    }
+
+    conn->enqueue_inq(ctx, conn, msg);
+    return NC_OK;
 }

--- a/src/nc_response.c
+++ b/src/nc_response.c
@@ -144,8 +144,11 @@ static bool
 rsp_filter(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     struct msg *pmsg;
+    struct server *server;
 
     ASSERT(!conn->client && !conn->proxy);
+
+    server = (struct server *)conn->owner;
 
     if (msg_empty(msg)) {
         ASSERT(conn->rmsg == NULL);
@@ -168,6 +171,12 @@ rsp_filter(struct context *ctx, struct conn *conn, struct msg *msg)
     ASSERT(pmsg->request && !pmsg->done);
 
     if (pmsg->swallow) {
+        if (server->fail == FAIL_STATUS_ERR_TRY_HEARTBEAT) {
+            struct conn *c_conn;
+
+            c_conn = pmsg->owner; 
+            server_restore_from_heartbeat(server, c_conn);
+        }
         conn->dequeue_outq(ctx, conn, pmsg);
         pmsg->done = 1;
 

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -66,6 +66,10 @@ struct continuum {
     uint32_t value;  /* hash value */
 };
 
+#define     FAIL_STATUS_NORMAL              0
+#define     FAIL_STATUS_ERR_TRY_CONNECT     1
+#define     FAIL_STATUS_ERR_TRY_HEARTBEAT   2
+
 struct server {
     uint32_t           idx;           /* server index */
     struct server_pool *owner;        /* owner pool */
@@ -83,6 +87,7 @@ struct server {
 
     int64_t            next_retry;    /* next retry time in usec */
     uint32_t           failure_count; /* # consecutive failures */
+    int                fail;          /* server fail status */
 };
 
 struct server_pool {
@@ -139,5 +144,9 @@ rstatus_t server_pool_preconnect(struct context *ctx);
 void server_pool_disconnect(struct context *ctx);
 rstatus_t server_pool_init(struct array *server_pool, struct array *conf_pool, struct context *ctx);
 void server_pool_deinit(struct array *server_pool);
+void server_restore(struct context *ctx, struct conn *conn);
+rstatus_t server_reconnect(struct context *ctx, struct server *server);
+void add_failed_server(struct context *ctx, struct server *server);
+void server_restore_from_heartbeat(struct server *server, struct conn *conn);
 
 #endif


### PR DESCRIPTION
There are 2 step to check connection.

step 1] trying to connect in server_failure

  If it succeed,  going to step 2

step 2] trying to send heartbeat command to fail server

 If it succeed, it will update hash ring.

and it uses array just to connect failed servers to prevent infinity loop for connecting

and in heartbeat stage. It uses msg_two_insert for timeout

but, if there is no timeout setting in conf, It will just wait for response like other message.
