### PR TITLE
Fix Long server  FQDN can not recognized

### DIFF
--- a/src/nc_util.c
+++ b/src/nc_util.c
@@ -458,7 +458,7 @@ nc_resolve_inet(struct string *name, int port, struct sockinfo *si)
     hints.ai_canonname = NULL;
 
     if (name != NULL) {
-    	node = name->data;
+        node = name->data;
     } else {
         /*
          * If AI_PASSIVE flag is specified in hints.ai_flags, and node is

--- a/src/nc_util.h
+++ b/src/nc_util.h
@@ -34,10 +34,6 @@
 #define VAR(s, s2, n)       (((n) < 2) ? 0.0 : ((s2) - SQUARE(s)/(n)) / ((n) - 1))
 #define STDDEV(s, s2, n)    (((n) < 2) ? 0.0 : sqrt(VAR((s), (s2), (n))))
 
-#define NC_INET4_ADDRSTRLEN (sizeof("255.255.255.255") - 1)
-#define NC_INET6_ADDRSTRLEN \
-    (sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255") - 1)
-#define NC_INET_ADDRSTRLEN  MAX(NC_INET4_ADDRSTRLEN, NC_INET6_ADDRSTRLEN)
 #define NC_UNIX_ADDRSTRLEN  \
     (sizeof(struct sockaddr_un) - offsetof(struct sockaddr_un, sun_path))
 


### PR DESCRIPTION
This patch allows over 44words FQDN for backend server name.

In AWS ElastiCache provides long server name (eg. cache-cluster-hoge.bixxxx.0001.apne1.cache.amazonaws.com)

But, 
https://github.com/twitter/twemproxy/blob/master/src/nc_util.c#L461
https://github.com/twitter/twemproxy/blob/master/src/nc_util.h#L40

NC_INET_ADDRSTRLEN limits 45words.
So, Domain is not recognized only up to 44 characters.
