### PR TITLE
Using autoconf

### DIFF
--- a/scripts/nutcracker.spec
+++ b/scripts/nutcracker.spec
@@ -15,6 +15,7 @@ It was primarily built to reduce the connection count on the backend caching ser
 
 %prep
 %setup -q
+autoreconf -fvi
 
 %build
 


### PR DESCRIPTION
If build nutcracker from source, configure file is missing.
This PR add autoconf command to spec file.

Please review this.
