### PR TITLE
exit 1 if configuration file is invalid

### DIFF
--- a/src/nc.c
+++ b/src/nc.c
@@ -430,7 +430,7 @@ nc_get_options(int argc, char **argv, struct instance *nci)
     return NC_OK;
 }
 
-static void
+static int
 nc_test_conf(struct instance *nci)
 {
     struct conf *cf;
@@ -439,13 +439,14 @@ nc_test_conf(struct instance *nci)
     if (cf == NULL) {
         log_stderr("nutcracker: configuration file '%s' syntax is invalid",
                    nci->conf_filename);
-        return;
+        return 1;
     }
 
     conf_destroy(cf);
 
     log_stderr("nutcracker: configuration file '%s' syntax is ok",
                nci->conf_filename);
+    return 0;
 }
 
 static rstatus_t
@@ -548,8 +549,7 @@ main(int argc, char **argv)
     }
 
     if (test_conf) {
-        nc_test_conf(&nci);
-        exit(0);
+        exit(nc_test_conf(&nci));
     }
 
     status = nc_pre_run(&nci);


### PR DESCRIPTION
usefull in reload/restart init script, when file is invalid, die with
errors.
