### PR TITLE
Support for redis AUTH Command

### DIFF
--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -74,6 +74,10 @@ static struct command conf_commands[] = {
       conf_set_bool,
       offsetof(struct conf_pool, redis) },
 
+    { string("redis_auth"),
+      conf_set_string,
+      offsetof(struct conf_pool, redis_auth) },
+
     { string("preconnect"),
       conf_set_bool,
       offsetof(struct conf_pool, preconnect) },
@@ -170,6 +174,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
 
     string_init(&cp->listen.pname);
     string_init(&cp->listen.name);
+    string_init(&cp->redis_auth);
     cp->listen.port = 0;
     memset(&cp->listen.info, 0, sizeof(cp->listen.info));
     cp->listen.valid = 0;
@@ -218,6 +223,10 @@ conf_pool_deinit(struct conf_pool *cp)
 
     string_deinit(&cp->listen.pname);
     string_deinit(&cp->listen.name);
+
+    if (cp->redis_auth.len > 0) {
+        string_deinit(&cp->redis_auth);
+    }
 
     while (array_n(&cp->server) != 0) {
         conf_server_deinit(array_pop(&cp->server));
@@ -268,6 +277,7 @@ conf_pool_each_transform(void *elem, void *data)
     sp->hash_tag = cp->hash_tag;
 
     sp->redis = cp->redis ? 1 : 0;
+    sp->redis_auth = cp->redis_auth;
     sp->timeout = cp->timeout;
     sp->backlog = cp->backlog;
 

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -81,6 +81,7 @@ struct conf_pool {
     int                backlog;               /* backlog: */
     int                client_connections;    /* client_connections: */
     int                redis;                 /* redis: */
+    struct string      redis_auth;            /* redis auth password */
     int                preconnect;            /* preconnect: */
     int                auto_eject_hosts;      /* auto_eject_hosts: */
     int                server_connections;    /* server_connections: */

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -84,6 +84,7 @@ struct conn {
     unsigned           eof:1;         /* eof? aka passive close? */
     unsigned           done:1;        /* done? aka close? */
     unsigned           redis:1;       /* redis? */
+    unsigned           auth:1;       /* auth flag */
 };
 
 TAILQ_HEAD(conn_tqh, conn);

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -145,6 +145,7 @@ typedef enum msg_type {
     MSG_REQ_REDIS_ZUNIONSTORE,
     MSG_REQ_REDIS_EVAL,                   /* redis requests - eval */
     MSG_REQ_REDIS_EVALSHA,
+    MSG_REQ_REDIS_AUTH,
     MSG_RSP_REDIS_STATUS,                 /* redis response */
     MSG_RSP_REDIS_ERROR,
     MSG_RSP_REDIS_INTEGER,

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -361,6 +361,74 @@ req_recv_next(struct context *ctx, struct conn *conn, bool alloc)
     return msg;
 }
 
+bool
+valid_auth(struct context *ctx, struct conn *conn, struct msg *msg) 
+{
+    struct server_pool *pool = (struct server_pool *)conn->owner;
+
+    if (pool->redis_auth.len > 0) {
+        long keylen = msg->key_end - msg->key_start;
+        if (keylen != pool->redis_auth.len) {
+            return false;
+        }
+
+        if (memcmp(pool->redis_auth.data, msg->key_start, keylen) != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static struct mbuf *
+get_mbuf(struct msg *msg) 
+{
+    struct mbuf *mbuf;
+
+    mbuf = STAILQ_LAST(&msg->mhdr, mbuf, next);
+    if (mbuf == NULL || mbuf_full(mbuf)) {
+        mbuf = mbuf_get();
+        if (mbuf == NULL) {
+            return NULL;
+        }
+
+        mbuf_insert(&msg->mhdr, mbuf);
+        msg->pos = mbuf->pos;
+    }
+    ASSERT(mbuf->end - mbuf->last > 0);
+    return mbuf;
+}
+
+static void
+reply(struct context *ctx, struct conn *conn, struct msg *smsg, char *_msg) {
+    struct mbuf *mbuf;
+    int n;
+    struct msg *msg = msg_get(conn, true, conn->redis);
+    if (msg == NULL) {
+        conn->err = errno;
+        return;
+    }
+
+    mbuf = get_mbuf(msg);
+    if (mbuf == NULL) {
+        msg_put(msg);
+        return;
+    }
+
+    smsg->peer = msg;
+    msg->peer = smsg;
+    msg->request = 0;
+
+    n = (int)strlen(_msg);
+    memcpy(mbuf->last, _msg, (size_t)n);
+    mbuf->last += n;
+    msg->mlen += (uint32_t)n;
+    smsg->done = 1;
+
+    event_add_out(ctx->ep, conn);
+    conn->enqueue_outq(ctx, conn, smsg);
+}
+
 static bool
 req_filter(struct context *ctx, struct conn *conn, struct msg *msg)
 {
@@ -385,6 +453,25 @@ req_filter(struct context *ctx, struct conn *conn, struct msg *msg)
         conn->eof = 1;
         conn->recv_ready = 0;
         req_put(msg);
+        return true;
+    }
+
+    /*
+     * Hanlde "AUTH requirepass\r\n"
+     *
+     */
+    if (conn->auth && conn->redis) {
+        if (msg->type == MSG_REQ_REDIS_AUTH) {
+            if (valid_auth(ctx, conn, msg)) {
+                conn->auth = 0;
+                reply(ctx, conn, msg, "+OK\r\n");
+            } else {
+                reply(ctx, conn, msg, "-ERR invalid password\r\n");
+            }
+        } else {
+            reply(ctx, conn, msg, "-ERR operation not permitted\r\n");
+        }
+
         return true;
     }
 
@@ -427,6 +514,56 @@ req_forward_stats(struct context *ctx, struct server *server, struct msg *msg)
 
     stats_server_incr(ctx, server, requests);
     stats_server_incr_by(ctx, server, request_bytes, msg->mlen);
+}
+
+static uint32_t
+set_redis_auth_command(struct mbuf *mbuf, struct string *pass)
+{
+#define REDIS_AUTH_COMMAND "*2\r\n$4\r\nAUTH\r\n"
+    int n;
+    char auth[1024];
+    n = nc_snprintf(auth, sizeof(auth), REDIS_AUTH_COMMAND "$%d\r\n%s\r\n",
+                    pass->len, pass->data);
+    memcpy(mbuf->last, auth, (size_t)n);
+    ASSERT((mbuf->last + n) <= mbuf->end);
+
+    return (uint32_t)n;
+}
+
+void
+add_redis_auth_packet(struct context *ctx, struct conn *c_conn, struct conn *s_conn)
+{
+    struct msg *msg;
+    struct mbuf *mbuf;
+    struct server_pool *pool;
+    uint32_t n;
+
+    pool = c_conn->owner;
+
+    if (s_conn->auth == 0 || pool->redis_auth.len == 0) {
+        return;
+    }
+
+    ASSERT(!s_conn->client && !s_conn->proxy);
+    msg = msg_get(c_conn, true, c_conn->redis);
+    if (msg == NULL) {
+        c_conn->err = errno;
+        return;
+    }
+
+    mbuf = get_mbuf(msg);
+    if (mbuf == NULL) {
+        msg_put(msg);
+        return;
+    }
+
+    n = set_redis_auth_command(mbuf, &(pool->redis_auth));
+    mbuf->last += n;
+    msg->mlen += n;
+    msg->swallow = 1;
+
+    s_conn->enqueue_inq(ctx, s_conn, msg);
+    s_conn->auth = 0;
 }
 
 static void
@@ -489,6 +626,11 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
             return;
         }
     }
+
+    if (s_conn->auth && s_conn->redis) {
+        add_redis_auth_packet(ctx, c_conn, s_conn);
+    }
+
     s_conn->enqueue_inq(ctx, s_conn, msg);
 
     req_forward_stats(ctx, s_conn->owner, msg);

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -102,6 +102,7 @@ struct server_pool {
 
     struct string      name;                 /* pool name (ref in conf_pool) */
     struct string      addrstr;              /* pool address (ref in conf_pool) */
+    struct string      redis_auth;           /* redis_auth password */
     uint16_t           port;                 /* port */
     int                family;               /* socket family */
     socklen_t          addrlen;              /* socket length */

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -55,6 +55,7 @@ redis_arg0(struct msg *r)
     case MSG_REQ_REDIS_SRANDMEMBER:
 
     case MSG_REQ_REDIS_ZCARD:
+    case MSG_REQ_REDIS_AUTH:
         return true;
 
     default:
@@ -545,6 +546,11 @@ redis_parse_req(struct msg *r)
 
                 if (str4icmp(m, 'e', 'v', 'a', 'l')) {
                     r->type = MSG_REQ_REDIS_EVAL;
+                    break;
+                }
+
+                if (str4icmp(m, 'a', 'u', 't', 'h')) {
+                    r->type = MSG_REQ_REDIS_AUTH;
                     break;
                 }
 


### PR DESCRIPTION
This patch supports redis AUTH Command, but not as User Command. 
In req_forward, this patch add auth packet in Request Queue when redis and redis_auth's length is not 0.

so. nc_connection has first flag. 

and add redis_auth keyword to conf file to use redis auth.

``` c
leaf:
  listen: 127.0.0.1:22121
  hash: fnv1a_64
  redis: true
  redis_auth: testpass
  distribution: ketama
  auto_eject_hosts: true
  server_retry_timeout: 2000
  server_failure_limit: 1
  servers:
   - 127.0.0.1:3001:1 server1
   - 127.0.0.1:3002:1 server2
```
# add changes
1. support user's auth command.
   -> twemproxy filters client's auth command and status.
      and, if client is not admitted, then return -ERR 
