### PR TITLE
remove whitechar in nc_conf.h(very trivial)

### DIFF
--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -120,7 +120,7 @@ char *conf_set_string(struct conf *cf, struct command *cmd, void *conf);
 char *conf_set_listen(struct conf *cf, struct command *cmd, void *conf);
 char *conf_add_server(struct conf *cf, struct command *cmd, void *conf);
 char *conf_set_num(struct conf *cf, struct command *cmd, void *conf);
-char * conf_set_bool(struct conf *cf, struct command *cmd, void *conf);
+char *conf_set_bool(struct conf *cf, struct command *cmd, void *conf);
 char *conf_set_hash(struct conf *cf, struct command *cmd, void *conf);
 char *conf_set_distribution(struct conf *cf, struct command *cmd, void *conf);
 char *conf_set_hashtag(struct conf *cf, struct command *cmd, void *conf);


### PR DESCRIPTION
There is just a odd space char at conf_set_bool in nc_conf.h
I just removed it. :)
