### PR TITLE
New Feature: Stats HTTP Response with -j

### DIFF
--- a/src/nc.c
+++ b/src/nc.c
@@ -56,6 +56,7 @@ static struct option long_options[] = {
     { "test-conf",      no_argument,        NULL,   't' },
     { "daemonize",      no_argument,        NULL,   'd' },
     { "describe-stats", no_argument,        NULL,   'D' },
+    { "http-stats",     no_argument,        NULL,   'j' },
     { "verbose",        required_argument,  NULL,   'v' },
     { "output",         required_argument,  NULL,   'o' },
     { "conf-file",      required_argument,  NULL,   'c' },
@@ -67,7 +68,7 @@ static struct option long_options[] = {
     { NULL,             0,                  NULL,    0  }
 };
 
-static char short_options[] = "hVtdDv:o:c:s:i:a:p:m:";
+static char short_options[] = "hVtdDjv:o:c:s:i:a:p:m:";
 
 static rstatus_t
 nc_daemonize(int dump_core)
@@ -201,7 +202,8 @@ nc_show_usage(void)
         "  -V, --version          : show version and exit" CRLF
         "  -t, --test-conf        : test configuration for syntax errors and exit" CRLF
         "  -d, --daemonize        : run as a daemon" CRLF
-        "  -D, --describe-stats   : print stats description and exit");
+        "  -D, --describe-stats   : print stats description and exit" CRLF
+        "  -j, --http-stats       ; set stats response with http protocol");
     log_stderr(
         "  -v, --verbosity=N      : set logging level (default: %d, min: %d, max: %d)" CRLF
         "  -o, --output=S         : set logging file (default: %s)" CRLF
@@ -276,6 +278,7 @@ nc_set_default_options(struct instance *nci)
     nci->stats_port = NC_STATS_PORT;
     nci->stats_addr = NC_STATS_ADDR;
     nci->stats_interval = NC_STATS_INTERVAL;
+    nci->stats_http_response = 0;
 
     status = nc_gethostname(nci->hostname, NC_MAXHOSTNAMELEN);
     if (status < 0) {
@@ -326,6 +329,10 @@ nc_get_options(int argc, char **argv, struct instance *nci)
         case 'D':
             describe_stats = 1;
             show_version = 1;
+            break;
+
+        case 'j':
+            nci->stats_http_response = 1;
             break;
 
         case 'v':

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -64,7 +64,8 @@ core_ctx_create(struct instance *nci)
     }
 
     /* create stats per server pool */
-    ctx->stats = stats_create(nci->stats_port, nci->stats_addr, nci->stats_interval,
+    ctx->stats = stats_create(nci->stats_port, nci->stats_addr, 
+                              nci->stats_interval, nci->stats_http_response,
                               nci->hostname, &ctx->pool);
     if (ctx->stats == NULL) {
         server_pool_deinit(&ctx->pool);

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -122,6 +122,7 @@ struct instance {
     pid_t           pid;                         /* process id */
     char            *pid_filename;               /* pid filename */
     unsigned        pidfile:1;                   /* pid file created? */
+    unsigned        stats_http_response:1;       /* stats http response */
 };
 
 struct context *core_start(struct instance *nci);

--- a/src/nc_stats.h
+++ b/src/nc_stats.h
@@ -91,6 +91,7 @@ struct stats {
     uint16_t            port;           /* stats monitoring port */
     int                 interval;       /* stats aggregation interval */
     struct string       addr;           /* stats monitoring address */
+    int                 http;           /* stats http response */
 
     int64_t             start_ts;       /* start timestamp of nutcracker */
     struct stats_buffer buf;            /* output buffer */
@@ -199,7 +200,7 @@ void _stats_server_decr(struct context *ctx, struct server *server, stats_server
 void _stats_server_incr_by(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
 void _stats_server_decr_by(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
 
-struct stats *stats_create(uint16_t stats_port, char *stats_ip, int stats_interval, char *source, struct array *server_pool);
+struct stats *stats_create(uint16_t stats_port, char *stats_ip, int stats_interval, int stats_http_response, char *source, struct array *server_pool);
 void stats_destroy(struct stats *stats);
 void stats_swap(struct stats *stats);
 


### PR DESCRIPTION
I added -j option 
If you use -j option then stats return http style response.
without -j: it is the same with before.
