### PR TITLE
Use sysconfdir & localstatedir for conf/pid/logs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,11 @@
 MAINTAINERCLEANFILES = Makefile.in
+BUILT_SOURCES = cfg-options.h
+CLEANFILES = cfg-options.h
+
+cfg-options.h: Makefile
+	$(AM_V_GEN)echo '#define NC_CONF_PATH "$(sysconfdir)/nutcracker/nutcracker.yml"' >$@
+	@echo '#define NC_LOG_PATH "$(localstatedir)/log/nutcracker/nutcracker.log"' >>$@
+	@echo '#define NC_PID_FILE "$(localstatedir)/run/nutcracker/nutcracker.pid"' >>$@
 
 AM_CPPFLAGS = -D_GNU_SOURCE -D_XOPEN_SOURCE
 AM_CPPFLAGS += -I $(top_srcdir)/src/hashkit

--- a/src/nc.c
+++ b/src/nc.c
@@ -27,18 +27,15 @@
 #include <nc_conf.h>
 #include <nc_signal.h>
 
-#define NC_CONF_PATH        "conf/nutcracker.yml"
+#include "cfg-options.h"
 
 #define NC_LOG_DEFAULT      LOG_NOTICE
 #define NC_LOG_MIN          LOG_EMERG
 #define NC_LOG_MAX          LOG_PVERB
-#define NC_LOG_PATH         NULL
 
 #define NC_STATS_PORT       STATS_PORT
 #define NC_STATS_ADDR       STATS_ADDR
 #define NC_STATS_INTERVAL   STATS_INTERVAL
-
-#define NC_PID_FILE         NULL
 
 #define NC_MBUF_SIZE        MBUF_SIZE
 #define NC_MBUF_MIN_SIZE    MBUF_MIN_SIZE
@@ -287,7 +284,7 @@ nc_set_default_options(struct instance *nci)
     nci->mbuf_chunk_size = NC_MBUF_SIZE;
 
     nci->pid = (pid_t)-1;
-    nci->pid_filename = NULL;
+    nci->pid_filename = NC_PID_FILE;
     nci->pidfile = 0;
 }
 


### PR DESCRIPTION
Use autoconf-supplied paths as the default values for the configuration
file, the pidfile and the logfile. So, for example:
  /etc/nutcracker/nutcracker.yml
  /var/run/nutcracker/nutcracker.pid
  /var/log/nutcracker/nutcracker.log

The separate subdirectory under /var/run was picked since nutcracker
doesn't possess the capability of dropping privileges by itself, so we
need to have a system user writeable directory to place the pidfile.

Similarly, we need a separate /var/log subdir as logs can't go to
syslog, and out of convenience (need to be able to perform logrotate,
cleanup upon removing a package etc.)

The separate subdirectory under /etc/ is just for being pretty
(top-level /etc conffiles are ugly) and for future use (multiple configs
for the same daemon?)

All of the above can of course be used in the case where a single init
script spawns multiple nutcrackers, each with a separate config, pidfile
and logfile, for example for extra redundancy reasons.

(also fix an underlying bug where NC_PID_FILE was completely unused)
