### PR TITLE
Move nutcracker to sbin instead of bin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,7 @@ AM_LDFLAGS = -lm -lpthread -rdynamic
 
 SUBDIRS = hashkit proto event
 
-bin_PROGRAMS = nutcracker
+sbin_PROGRAMS = nutcracker
 
 nutcracker_SOURCES =			\
 	nc_core.c nc_core.h		\


### PR DESCRIPTION
nutcracker is a daemon, so it obviously belongs to /usr/sbin, not
/usr/bin/.
