### PR TITLE
RPM SPEC Changes

### DIFF
--- a/scripts/nutcracker.spec
+++ b/scripts/nutcracker.spec
@@ -55,7 +55,11 @@ fi
 
 %files
 %defattr(-,root,root,-)
+%if 0%{?rhel} == 6
 /usr/sbin/nutcracker
+%else
+/usr/bin/nutcracker
+%endif
 %{_initrddir}/%{name}
 %{_mandir}/man8/nutcracker.8.gz
 %config(noreplace)%{_sysconfdir}/%{name}/%{name}.yml


### PR DESCRIPTION
- Bumped version
- Added buildrequires
- Added CentOS 6 specific if statements for:
  - Autoconf is 2.63 (not the required 2.64)
  - Binary is in /usr/sbin instead of /usr/bin (not sure if this is CentOS specific)
- Added man files to installed files
- Added a bit of a changelog (dates in the master/CHANGELOG seemed to flip randomly between YYYY-MM-DD and YYYY-DD-MM)

If someone can test with Fedora/any other RPM distro to make sure it works, I can confirm it works in CentOS 6.x (both build and run)
