### PR TITLE
Handle case where server responds while the request is still being sent

### DIFF
--- a/src/nc_response.c
+++ b/src/nc_response.c
@@ -159,10 +159,12 @@ rsp_filter(struct context *ctx, struct conn *conn, struct msg *msg)
                   msg->id, msg->mlen, conn->sd);
         rsp_put(msg);
 
-        /* this can happen as a result of some server errors like object-too-big.
-           closing the connection is the safest response. */
+        /*
+         * This can happen as a result of some server errors like object-too-big.
+         * closing the connection is the safest response.
+         */
+        conn->err = EINVAL;
         conn->done = 1;
-        log_debug(LOG_NOTICE, "s %d is done", conn->sd);
         return true;
     }
     ASSERT(pmsg->peer == NULL);


### PR DESCRIPTION
  (usually SERVER_ERROR)

  Forward response, cancel send, and cleanup connection

See https://github.com/twitter/twemproxy/issues/149
