### PR TITLE
[New Feature] adding to always resolve hostname with always_host_resolve option.

### DIFF
--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -74,6 +74,10 @@ static struct command conf_commands[] = {
       conf_set_bool,
       offsetof(struct conf_pool, redis) },
 
+    { string("always_host_resolve"),
+      conf_set_bool,
+      offsetof(struct conf_pool, always_host_resolve) },
+
     { string("preconnect"),
       conf_set_bool,
       offsetof(struct conf_pool, preconnect) },
@@ -106,6 +110,7 @@ conf_server_init(struct conf_server *cs)
 {
     string_init(&cs->pname);
     string_init(&cs->name);
+    string_init(&cs->address);
     cs->port = 0;
     cs->weight = 0;
 
@@ -121,6 +126,7 @@ conf_server_deinit(struct conf_server *cs)
 {
     string_deinit(&cs->pname);
     string_deinit(&cs->name);
+    string_deinit(&cs->address);
     cs->valid = 0;
     log_debug(LOG_VVERB, "deinit conf server %p", cs);
 }
@@ -142,6 +148,7 @@ conf_server_each_transform(void *elem, void *data)
 
     s->pname = cs->pname;
     s->name = cs->name;
+    s->address = cs->address;
     s->port = (uint16_t)cs->port;
     s->weight = (uint32_t)cs->weight;
 
@@ -152,6 +159,7 @@ conf_server_each_transform(void *elem, void *data)
     s->ns_conn_q = 0;
     TAILQ_INIT(&s->s_conn_q);
 
+    memset(&s->info, 0, sizeof(s->info));
     s->next_retry = 0LL;
     s->failure_count = 0;
 
@@ -184,6 +192,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
     cp->client_connections = CONF_UNSET_NUM;
 
     cp->redis = CONF_UNSET_NUM;
+    cp->always_host_resolve = CONF_UNSET_NUM;
     cp->preconnect = CONF_UNSET_NUM;
     cp->auto_eject_hosts = CONF_UNSET_NUM;
     cp->server_connections = CONF_UNSET_NUM;
@@ -268,6 +277,7 @@ conf_pool_each_transform(void *elem, void *data)
     sp->hash_tag = cp->hash_tag;
 
     sp->redis = cp->redis ? 1 : 0;
+    sp->always_host_resolve = cp->always_host_resolve ? 1 : 0;
     sp->timeout = cp->timeout;
     sp->backlog = cp->backlog;
 
@@ -1473,10 +1483,8 @@ conf_add_server(struct conf *cf, struct command *cmd, void *conf)
     uint8_t *p, *q, *start;
     uint8_t *pname, *addr, *port, *weight, *name;
     uint32_t k, delimlen, pnamelen, addrlen, portlen, weightlen, namelen;
-    struct string address;
     char delim[] = " ::";
 
-    string_init(&address);
     p = conf;
     a = (struct array *)(p + cmd->offset);
 
@@ -1586,18 +1594,16 @@ conf_add_server(struct conf *cf, struct command *cmd, void *conf)
         return CONF_ERROR;
     }
 
-    status = string_copy(&address, addr, addrlen);
+    status = string_copy(&(field->address), addr, addrlen);
     if (status != NC_OK) {
         return CONF_ERROR;
     }
 
-    status = nc_resolve(&address, field->port, &field->info);
+    status = nc_resolve(&(field->address), field->port, &field->info);
     if (status != NC_OK) {
-        string_deinit(&address);
         return CONF_ERROR;
     }
 
-    string_deinit(&address);
     field->valid = 1;
 
     return CONF_OK;

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -65,6 +65,7 @@ struct conf_listen {
 struct conf_server {
     struct string   pname;      /* server: as "name:port:weight" */
     struct string   name;       /* name */
+    struct string   address;    /* address */
     int             port;       /* port */
     int             weight;     /* weight */
     struct sockinfo info;       /* connect socket info */
@@ -81,6 +82,7 @@ struct conf_pool {
     int                backlog;               /* backlog: */
     int                client_connections;    /* client_connections: */
     int                redis;                 /* redis: */
+    int                always_host_resolve;   /* always_host_resolve: */
     int                preconnect;            /* preconnect: */
     int                auto_eject_hosts;      /* auto_eject_hosts: */
     int                server_connections;    /* server_connections: */

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -30,8 +30,20 @@ server_ref(struct conn *conn, void *owner)
     ASSERT(!conn->client && !conn->proxy);
     ASSERT(conn->owner == NULL);
 
+    struct server_pool *pool = server->owner;
+
     conn->family = server->family;
     conn->addrlen = server->addrlen;
+
+    if (pool->always_host_resolve) {
+        nc_resolve(&(server->address), server->port, &(server->info));
+        server->addr = (struct sockaddr *)&(server->info.addr);
+        struct in_addr inaddr = ((struct sockaddr_in *)(server->addr))->sin_addr;
+        unsigned char *ptr = (char *)(&inaddr);
+        log_debug(LOG_NOTICE, "resolve ip: %u.%u.%u.%u", 
+            ptr[0], ptr[1], ptr[2], ptr[3]);
+    }
+
     conn->addr = server->addr;
 
     server->ns_conn_q++;

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -72,11 +72,13 @@ struct server {
 
     struct string      pname;         /* name:port:weight (ref in conf_server) */
     struct string      name;          /* name (ref in conf_server) */
+    struct string      address;       /* address (ref in conf_server) */
     uint16_t           port;          /* port */
     uint32_t           weight;        /* weight */
     int                family;        /* socket family */
     socklen_t          addrlen;       /* socket length */
     struct sockaddr    *addr;         /* socket address (ref in conf_server) */
+    struct sockinfo info;             /* connect socket info */
 
     uint32_t           ns_conn_q;     /* # server connection */
     struct conn_tqh    s_conn_q;      /* server connection q */
@@ -119,6 +121,7 @@ struct server_pool {
     unsigned           auto_eject_hosts:1;   /* auto_eject_hosts? */
     unsigned           preconnect:1;         /* preconnect? */
     unsigned           redis:1;              /* redis? */
+    unsigned           always_host_resolve:1;/* always_host_resolve? */
 };
 
 void server_ref(struct conn *conn, void *owner);


### PR DESCRIPTION
if set always_host_resolve to true:

It always tries to resolve when reconnect to server.

before patch
1. read conf
2. resolve host address
3. connect
4. disconnect
5. connect with 2's info

after patch("always_host_resolve: true)
1. read conf
2. resolve host address
3. connect
4. disconnect
5. resolve host address again.
6. connect with 5's info
 
