### PR TITLE
Make include guards unique.

### DIFF
--- a/src/event/nc_event.h
+++ b/src/event/nc_event.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_EVENT_H_
-#define _NC_EVENT_H_
+#ifndef NC_EVENT_H_4BC4E9B7B52641CE92BD57D6E39B6C85
+#define NC_EVENT_H_4BC4E9B7B52641CE92BD57D6E39B6C85
 
 #include <nc_core.h>
 

--- a/src/hashkit/nc_hashkit.h
+++ b/src/hashkit/nc_hashkit.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_HASHKIT_H_
-#define _NC_HASHKIT_H_
+#ifndef NC_HASHKIT_H_67BE98BD03D14FABA3267EBA447D75E4
+#define NC_HASHKIT_H_67BE98BD03D14FABA3267EBA447D75E4
 
 #include <nc_core.h>
 #include <nc_server.h>

--- a/src/nc_array.h
+++ b/src/nc_array.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_ARRAY_H_
-#define _NC_ARRAY_H_
+#ifndef NC_ARRAY_H_0F1C20D95CC24E229B5BE985A5984BDF
+#define NC_ARRAY_H_0F1C20D95CC24E229B5BE985A5984BDF
 
 #include <nc_core.h>
 

--- a/src/nc_client.h
+++ b/src/nc_client.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_CLIENT_H_
-#define _NC_CLIENT_H_
+#ifndef NC_CLIENT_H_AC3C4D0E44AC4FBD83D0E9B747BE23FD
+#define NC_CLIENT_H_AC3C4D0E44AC4FBD83D0E9B747BE23FD
 
 #include <nc_core.h>
 

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_CONF_H_
-#define _NC_CONF_H_
+#ifndef NC_CONF_H_303C826E50F34210968F6BAA45C8C202
+#define NC_CONF_H_303C826E50F34210968F6BAA45C8C202
 
 #include <unistd.h>
 #include <sys/types.h>

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_CONNECTION_H_
-#define _NC_CONNECTION_H_
+#ifndef NC_CONNECTION_H_4B3EEA545439488AA629242B69A08F0B
+#define NC_CONNECTION_H_4B3EEA545439488AA629242B69A08F0B
 
 #include <nc_core.h>
 

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_CORE_H_
-#define _NC_CORE_H_
+#ifndef NC_CORE_H_A2CCF95F4FF9498790DE979DDA59441A
+#define NC_CORE_H_A2CCF95F4FF9498790DE979DDA59441A
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/nc_log.h
+++ b/src/nc_log.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_LOG_H_
-#define _NC_LOG_H_
+#ifndef NC_LOG_H_B29D74ABB74E49A1BF4879F76A2E4261
+#define NC_LOG_H_B29D74ABB74E49A1BF4879F76A2E4261
 
 struct logger {
     char *name;  /* log file name */

--- a/src/nc_mbuf.h
+++ b/src/nc_mbuf.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_MBUF_H_
-#define _NC_MBUF_H_
+#ifndef NC_MBUF_H_026E7B82C18943139416928CEE5D987F
+#define NC_MBUF_H_026E7B82C18943139416928CEE5D987F
 
 #include <nc_core.h>
 

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_MESSAGE_H_
-#define _NC_MESSAGE_H_
+#ifndef NC_MESSAGE_H_BEDD33363EE0457680AED439102A42B6
+#define NC_MESSAGE_H_BEDD33363EE0457680AED439102A42B6
 
 #include <nc_core.h>
 

--- a/src/nc_proxy.h
+++ b/src/nc_proxy.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_PROXY_H_
-#define _NC_PROXY_H_
+#ifndef NC_PROXY_H_0EFE6BC353564ECF8DF1199E947C5357
+#define NC_PROXY_H_0EFE6BC353564ECF8DF1199E947C5357
 
 #include <nc_core.h>
 

--- a/src/nc_queue.h
+++ b/src/nc_queue.h
@@ -47,8 +47,8 @@
  * $FreeBSD: src/sys/sys/queue.h,v 1.73 2010/02/20 01:05:30 emaste Exp $
  */
 
-#ifndef _NC_QUEUE_H_
-#define _NC_QUEUE_H_
+#ifndef NC_QUEUE_H_878061AB4F4341298A1A06780ECB8160
+#define NC_QUEUE_H_878061AB4F4341298A1A06780ECB8160
 
 #include <nc_log.h>
 

--- a/src/nc_rbtree.h
+++ b/src/nc_rbtree.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_RBTREE_
-#define _NC_RBTREE_
+#ifndef NC_RBTREE_H_373370C1A0E248A8925D17009BD90027
+#define NC_RBTREE_H_373370C1A0E248A8925D17009BD90027
 
 #define rbtree_red(_node)           ((_node)->color = 1)
 #define rbtree_black(_node)         ((_node)->color = 0)

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_SERVER_H_
-#define _NC_SERVER_H_
+#ifndef NC_SERVER_H_FFB5CC8CF88A486EA0E6DA81AD51014F
+#define NC_SERVER_H_FFB5CC8CF88A486EA0E6DA81AD51014F
 
 #include <nc_core.h>
 

--- a/src/nc_signal.h
+++ b/src/nc_signal.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_SIGNAL_H_
-#define _NC_SIGNAL_H_
+#ifndef NC_SIGNAL_H_F89A48B8544E49C8BCA89F025BF94E55
+#define NC_SIGNAL_H_F89A48B8544E49C8BCA89F025BF94E55
 
 #include <nc_core.h>
 

--- a/src/nc_stats.h
+++ b/src/nc_stats.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_STATS_H_
-#define _NC_STATS_H_
+#ifndef NC_STATS_H_C69932D0294C48FA92E1BED3063B22E3
+#define NC_STATS_H_C69932D0294C48FA92E1BED3063B22E3
 
 #include <nc_core.h>
 

--- a/src/nc_string.h
+++ b/src/nc_string.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_STRING_H_
-#define _NC_STRING_H_
+#ifndef NC_STRING_H_5C551163871C4A70A31613EF877C4B4D
+#define NC_STRING_H_5C551163871C4A70A31613EF877C4B4D
 
 #include <string.h>
 #include <nc_core.h>

--- a/src/nc_util.h
+++ b/src/nc_util.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_UTIL_H_
-#define _NC_UTIL_H_
+#ifndef NC_UTIL_H_81E871276FF149D58A44072A88870E22
+#define NC_UTIL_H_81E871276FF149D58A44072A88870E22
 
 #include <stdarg.h>
 

--- a/src/proto/nc_proto.h
+++ b/src/proto/nc_proto.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _NC_PROTO_H_
-#define _NC_PROTO_H_
+#ifndef NC_PROTO_H_7DAF4377669D4EA69D026395004507F4
+#define NC_PROTO_H_7DAF4377669D4EA69D026395004507F4
 
 #include <nc_core.h>
 


### PR DESCRIPTION
Some include guards do not fit to the expected naming convention of the C language standard. This detail can be fixed by the deletion of leading underscores.

The probability for name clashes can also be reduced by the addition of a kind of universally unique identifier as a suffix.

This update suggestion corresponds to the issue "[reserved identifier violation](https://github.com/twitter/twemproxy/issues/155)".
