### PR TITLE
fix the bug in string_compare

### DIFF
--- a/src/nc_string.c
+++ b/src/nc_string.c
@@ -102,7 +102,7 @@ int
 string_compare(const struct string *s1, const struct string *s2)
 {
     if (s1->len != s2->len) {
-        return s1->len - s2->len > 0 ? 1 : -1;
+        return s1->len > s2->len ? 1 : -1;
     }
 
     return nc_strncmp(s1->data, s2->data, s1->len);


### PR DESCRIPTION
fix the bug in string_compare when the string length are not equal.
