### PR TITLE
Support for selecting Redis databases before executing actual commands

### DIFF
--- a/conf/nutcracker.yml
+++ b/conf/nutcracker.yml
@@ -8,6 +8,7 @@ alpha:
   server_failure_limit: 1
   servers:
    - 127.0.0.1:6379:1
+  database: 1
 
 beta:
   listen: 127.0.0.1:22122

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -66,6 +66,10 @@ static struct command conf_commands[] = {
       conf_set_num,
       offsetof(struct conf_pool, backlog) },
 
+    { string("database"),
+      conf_set_num,
+      offsetof(struct conf_pool, database) },
+
     { string("client_connections"),
       conf_set_num,
       offsetof(struct conf_pool, client_connections) },
@@ -180,6 +184,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
 
     cp->timeout = CONF_UNSET_NUM;
     cp->backlog = CONF_UNSET_NUM;
+    cp->database = CONF_UNSET_NUM;
 
     cp->client_connections = CONF_UNSET_NUM;
 
@@ -266,6 +271,7 @@ conf_pool_each_transform(void *elem, void *data)
     sp->key_hash = hash_algos[cp->hash];
     sp->dist_type = cp->distribution;
     sp->hash_tag = cp->hash_tag;
+    sp->database = cp->database;
 
     sp->redis = cp->redis ? 1 : 0;
     sp->timeout = cp->timeout;
@@ -1213,6 +1219,10 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
 
     if (cp->preconnect == CONF_UNSET_NUM) {
         cp->preconnect = CONF_DEFAULT_PRECONNECT;
+    }
+
+    if (cp->database == CONF_UNSET_NUM) {
+        cp->database = CONF_DEFAULT_DATABASE;
     }
 
     if (cp->auto_eject_hosts == CONF_UNSET_NUM) {

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -48,6 +48,7 @@
 #define CONF_DEFAULT_CLIENT_CONNECTIONS      0
 #define CONF_DEFAULT_REDIS                   false
 #define CONF_DEFAULT_PRECONNECT              false
+#define CONF_DEFAULT_DATABASE                0
 #define CONF_DEFAULT_AUTO_EJECT_HOSTS        false
 #define CONF_DEFAULT_SERVER_RETRY_TIMEOUT    30 * 1000      /* in msec */
 #define CONF_DEFAULT_SERVER_FAILURE_LIMIT    2
@@ -82,6 +83,7 @@ struct conf_pool {
     int                client_connections;    /* client_connections: */
     int                redis;                 /* redis: */
     int                preconnect;            /* preconnect: */
+    int                database;              /* Redis database to select (connect to) */
     int                auto_eject_hosts;      /* auto_eject_hosts: */
     int                server_connections;    /* server_connections: */
     int                server_retry_timeout;  /* server_retry_timeout: in msec */

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -195,6 +195,8 @@ conn_get(void *owner, bool client, bool redis)
         conn->dequeue_inq = NULL;
         conn->enqueue_outq = req_client_enqueue_omsgq;
         conn->dequeue_outq = req_client_dequeue_omsgq;
+
+        conn->initialize = NULL;
     } else {
         /*
          * server receives a response, possibly parsing it, and sends a
@@ -218,6 +220,8 @@ conn_get(void *owner, bool client, bool redis)
         conn->dequeue_inq = req_server_dequeue_imsgq;
         conn->enqueue_outq = req_server_enqueue_omsgq;
         conn->dequeue_outq = req_server_dequeue_omsgq;
+
+        conn->initialize = server_conn_init;
     }
 
     conn->ref(conn, owner);

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -36,6 +36,8 @@ typedef void (*conn_unref_t)(struct conn *);
 
 typedef void (*conn_msgq_t)(struct context *, struct conn *, struct msg *);
 
+typedef void (*conn_initialize_t )(struct conn *, struct server *server);
+
 struct conn {
     TAILQ_ENTRY(conn)  conn_tqe;      /* link in server_pool / server / free q */
     void               *owner;        /* connection owner - server_pool / server */
@@ -84,6 +86,9 @@ struct conn {
     unsigned           eof:1;         /* eof? aka passive close? */
     unsigned           done:1;        /* done? aka close? */
     unsigned           redis:1;       /* redis? */
+    unsigned           initializing:1;/* connection initializing state (to track first Redis "SELECT" command) */
+
+    conn_initialize_t  initialize;    /* initialize connection handler */
 };
 
 TAILQ_HEAD(conn_tqh, conn);

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -529,6 +529,19 @@ req_send_next(struct context *ctx, struct conn *conn)
         server_connected(ctx, conn);
     }
 
+    // if the connection is initializing, skip all the rest requests for now,
+    // but still keep them in the queue for further processing if the
+    // initialization succeeds.
+    if (conn->initializing) {
+        return NC_OK;
+    }
+
+    // if the connection is dead for some reason (e.g. it hasn't been initialized
+    // correctly), ignore the request
+    if (!conn->connected) {
+        return NULL;
+    }
+
     nmsg = TAILQ_FIRST(&conn->imsg_q);
     if (nmsg == NULL) {
         /* nothing to send as the server inq is empty */

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -111,6 +111,7 @@ struct server_pool {
     hash_t             key_hash;             /* key hasher */
     struct string      hash_tag;             /* key hash tag (ref in conf_pool) */
     int                timeout;              /* timeout in msec */
+    int                database;             /* Redis database to select (connect to) */
     int                backlog;              /* listen backlog */
     uint32_t           client_connections;   /* maximum # client connection */
     uint32_t           server_connections;   /* maximum # server connection */
@@ -139,5 +140,7 @@ rstatus_t server_pool_preconnect(struct context *ctx);
 void server_pool_disconnect(struct context *ctx);
 rstatus_t server_pool_init(struct array *server_pool, struct array *conf_pool, struct context *ctx);
 void server_pool_deinit(struct array *server_pool);
+
+void server_conn_init(struct conn *conn, struct server *server);
 
 #endif


### PR DESCRIPTION
These changes are based on those of Niteesh (https://github.com/twitter/twemproxy/pull/102). The main difference is more correct parameters naming and handling the case when Redis "SELECT" command failed for some reason (for example, there was no such database in Redis) to prevent sending the next (actual client's) commands to Redis as they can be sent to the wrong database.
