### PR TITLE
another mget improvement

### DIFF
--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -235,6 +235,8 @@ done:
 
     msg->frag_owner = NULL;
     msg->nfrag = 0;
+    msg->nfrag_done = 0;
+    msg->nfrag_error = 0;
     msg->frag_id = 0;
 
     msg->narg_start = NULL;

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -198,6 +198,8 @@ struct msg {
 
     struct msg           *frag_owner;     /* owner of fragment message */
     uint32_t             nfrag;           /* # fragment */
+    uint32_t             nfrag_done;      /* # fragment done */
+    uint32_t             nfrag_error;     /* # fragment error */
     uint64_t             frag_id;         /* id of fragmented message */
 
     err_t                err;             /* errno on error? */

--- a/src/nc_response.c
+++ b/src/nc_response.c
@@ -187,6 +187,9 @@ rsp_filter(struct context *ctx, struct conn *conn, struct msg *msg)
     if (pmsg->swallow) {
         conn->dequeue_outq(ctx, conn, pmsg);
         pmsg->done = 1;
+        if (pmsg->frag_owner) {
+            pmsg->frag_owner->nfrag_done++;
+        }
 
         log_debug(LOG_INFO, "swallow rsp %"PRIu64" len %"PRIu32" of req "
                   "%"PRIu64" on s %d", msg->id, msg->mlen, pmsg->id,
@@ -228,6 +231,9 @@ rsp_forward(struct context *ctx, struct conn *s_conn, struct msg *msg)
 
     s_conn->dequeue_outq(ctx, s_conn, pmsg);
     pmsg->done = 1;
+    if (pmsg->frag_owner) {
+        pmsg->frag_owner->nfrag_done++;
+    }
 
     /* establish msg <-> pmsg (response <-> request) link */
     pmsg->peer = msg;

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -366,6 +366,10 @@ server_close(struct context *ctx, struct conn *conn)
 
             msg->done = 1;
             msg->error = 1;
+            if (msg->frag_owner) {
+                msg->frag_owner->nfrag_done++;
+                msg->frag_owner->nfrag_error++;
+            }
             msg->err = conn->err;
 
             if (req_done(c_conn, TAILQ_FIRST(&c_conn->omsg_q))) {
@@ -396,6 +400,10 @@ server_close(struct context *ctx, struct conn *conn)
 
             msg->done = 1;
             msg->error = 1;
+            if (msg->frag_owner) {
+                msg->frag_owner->nfrag_done++;
+                msg->frag_owner->nfrag_error++;
+            }
             msg->err = conn->err;
 
             if (req_done(c_conn, TAILQ_FIRST(&c_conn->omsg_q))) {

--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -1289,6 +1289,9 @@ memcache_pre_coalesce(struct msg *r)
         log_hexdump(LOG_ERR, mbuf->pos, mbuf_length(mbuf), "rsp fragment "
                     "with unknown type %d", r->type);
         pr->error = 1;
+        if (pr->frag_owner) {
+            pr->frag_owner->nfrag_error++;
+        }
         pr->err = EINVAL;
         break;
     }

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -2053,6 +2053,9 @@ redis_pre_coalesce(struct msg *r)
             mbuf = mbuf_get();
             if (mbuf == NULL) {
                 pr->error = 1;
+                if (pr->frag_owner) {
+                    pr->frag_owner->nfrag_error++;
+                }
                 pr->err = EINVAL;
                 return;
             }
@@ -2070,6 +2073,9 @@ redis_pre_coalesce(struct msg *r)
         log_hexdump(LOG_ERR, mbuf->pos, mbuf_length(mbuf), "rsp fragment "
                     "with unknown type %d", r->type);
         pr->error = 1;
+        if (pr->frag_owner) {
+            pr->frag_owner->nfrag_error++;
+        }
         pr->err = EINVAL;
         break;
     }


### PR DESCRIPTION
I noticed that mget performance is bad in twemproxy for some time. And I'm trying to improve it.

Here how it works:
req_error or req_done is called several times to verify the request is done or error. As for mget, when every response is got from backend, it may need to verify, so req_error or req_done may be called many many times.
The key point is that it traverses the link list to do the verification. Assume the number of keys in mget is N, the time cost will be O(N*N) (called by N times, traverses N link nodes).
I use a counter to trace the number of message which is done or error, and check it first before the traversal.

Performance checking, which I tested on our server:

```
mget 3000 keys
client => proxy(not improved) => redis: avg 327.06ms
client => redis: avg 28.36ms
client => proxy(improved) => redis: avg 41.04ms
```

Compared to the non-improved version, it's about 8 times.
Compared to sending to redis directly, it slows down about 30%. I use google cpu profiler to find that memcpy function cost about 36% time. memcpy is called a lot of times in msg split.

```
Total: 173 samples
      63  36.4%  36.4%       63  36.4% __memcpy_ssse3
      27  15.6%  52.0%       27  15.6% __libc_writev
      10   5.8%  57.8%       10   5.8% _mbuf_get (inline)
      10   5.8%  63.6%       37  21.4% msg_send_chain
...
```

BTW, it works both for memcache and redis.
Hope this work helps.

ps. 
After I finished my work, I found out that there is another pull request #210 from @idning, which support MSET.
IMHO, my commits is easier to review and merge. 
