### PR TITLE
increase maximum mbuf size

### DIFF
--- a/src/nc_mbuf.h
+++ b/src/nc_mbuf.h
@@ -35,7 +35,7 @@ STAILQ_HEAD(mhdr, mbuf);
 
 #define MBUF_MAGIC      0xdeadbeef
 #define MBUF_MIN_SIZE   512
-#define MBUF_MAX_SIZE   65536
+#define MBUF_MAX_SIZE   10485760
 #define MBUF_SIZE       16384
 #define MBUF_HSIZE      sizeof(struct mbuf)
 


### PR DESCRIPTION
We've been trying out nutcracker at Twitch for a couple months now, and one use case we have is using nutcracker/redis to power a storage system which stores ephemeral chat room membership info (100K's of users in some rooms).  One part of our data flow involves periodically sending redis large batches (hundreds of kilobytes) of single-fragment requests in the form of HMSET operations (we also do large HMGET operations).  We have a small fixed-size connection pool from our client to nutcracker, and a relatively small number of connections between each nutcracker and redis instance.

In my use case I'd like a much larger mbuf size, since I have a good idea of how my requests are shaped and I know I'll have few connections.  In general I feel that the user should be responsible for choosing an appropriate mbuf size for their use case, and so I would like to see a much higher maximum mbuf_size.  What are your thoughts?
