### PR TITLE
Added specifying ordinal hash tag positions

### DIFF
--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -54,6 +54,10 @@ static struct command conf_commands[] = {
       conf_set_hashtag,
       offsetof(struct conf_pool, hash_tag) },
 
+    { string("hash_tag_pos"),
+      conf_set_num,
+      offsetof(struct conf_pool, hash_tag_pos) },
+
     { string("distribution"),
       conf_set_distribution,
       offsetof(struct conf_pool, distribution) },
@@ -176,6 +180,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
 
     cp->hash = CONF_UNSET_HASH;
     string_init(&cp->hash_tag);
+    cp->hash_tag_pos = CONF_UNSET_NUM;
     cp->distribution = CONF_UNSET_DIST;
 
     cp->timeout = CONF_UNSET_NUM;
@@ -266,6 +271,7 @@ conf_pool_each_transform(void *elem, void *data)
     sp->key_hash = hash_algos[cp->hash];
     sp->dist_type = cp->distribution;
     sp->hash_tag = cp->hash_tag;
+    sp->hash_tag_pos = cp->hash_tag_pos;
 
     sp->redis = cp->redis ? 1 : 0;
     sp->timeout = cp->timeout;
@@ -316,6 +322,7 @@ conf_dump(struct conf *cf)
         log_debug(LOG_VVERB, "  hash: %d", cp->hash);
         log_debug(LOG_VVERB, "  hash_tag: \"%.*s\"", cp->hash_tag.len,
                   cp->hash_tag.data);
+        log_debug(LOG_VVERB, "  hash_tag_pos: %d", cp->hash_tag_pos);
         log_debug(LOG_VVERB, "  distribution: %d", cp->distribution);
         log_debug(LOG_VVERB, "  client_connections: %d",
                   cp->client_connections);
@@ -1195,6 +1202,10 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
 
     if (cp->hash == CONF_UNSET_HASH) {
         cp->hash = CONF_DEFAULT_HASH;
+    }
+
+    if (cp->hash_tag_pos == CONF_UNSET_NUM) {
+        cp->hash_tag_pos = CONF_DEFAULT_HASH_TAG_POS;
     }
 
     if (cp->timeout == CONF_UNSET_NUM) {

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -43,6 +43,7 @@
 
 #define CONF_DEFAULT_HASH                    HASH_FNV1A_64
 #define CONF_DEFAULT_DIST                    DIST_KETAMA
+#define CONF_DEFAULT_HASH_TAG_POS            1              /* rank (i.e. nth) */
 #define CONF_DEFAULT_TIMEOUT                 -1
 #define CONF_DEFAULT_LISTEN_BACKLOG          512
 #define CONF_DEFAULT_CLIENT_CONNECTIONS      0
@@ -76,6 +77,7 @@ struct conf_pool {
     struct conf_listen listen;                /* listen: */
     hash_type_t        hash;                  /* hash: */
     struct string      hash_tag;              /* hash_tag: */
+    int                hash_tag_pos;          /* hash_tag_pos: */
     dist_type_t        distribution;          /* distribution: */
     int                timeout;               /* timeout: */
     int                backlog;               /* backlog: */

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -457,12 +457,26 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
         struct string *tag = &pool->hash_tag;
         uint8_t *tag_start, *tag_end;
 
+        int cur_tag_pos = 0;
         tag_start = nc_strchr(msg->key_start, msg->key_end, tag->data[0]);
-        if (tag_start != NULL) {
-            tag_end = nc_strchr(tag_start + 1, msg->key_end, tag->data[1]);
-            if (tag_end != NULL) {
-                key = tag_start + 1;
-                keylen = (uint32_t)(tag_end - key);
+        for(; cur_tag_pos < *(&pool->hash_tag_pos); cur_tag_pos++) {
+            if (tag_start != NULL) {
+                tag_end = nc_strchr(tag_start + 1, msg->key_end, tag->data[1]);
+                if (tag_end != NULL) {
+                    key = tag_start + 1;
+                    if(cur_tag_pos+1 == *(&pool->hash_tag_pos)) {
+                        keylen = (uint32_t)(tag_end - key);
+                    }
+                    else {
+                        tag_start = tag_end;
+                    }
+                }
+                else {
+                    break;
+                }
+            }
+            else {
+                break;
             }
         }
     }

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -110,6 +110,7 @@ struct server_pool {
     int                key_hash_type;        /* key hash type (hash_type_t) */
     hash_t             key_hash;             /* key hasher */
     struct string      hash_tag;             /* key hash tag (ref in conf_pool) */
+    int                hash_tag_pos;         /* key hash tag position (ref in conf_pool) */
     int                timeout;              /* timeout in msec */
     int                backlog;              /* listen backlog */
     uint32_t           client_connections;   /* maximum # client connection */


### PR DESCRIPTION
if the start hash tag character is the same as the end hash tag character, only the first hash tag will be used

```
hash_tag: __
1_2_3_4 -> 2
```

Applying ordinal hash tag positions, you can get the nth hash tag if multiple hash tags exist, reverts to whole key if nth hash tag is not found

```
hash_tag: __
hash_tag_pos: 2
1_2_3_4 -> 3

hash_tag:__
hash_tag_pos: 2
1_2_3 -> 1_2_3
```
