### PR TITLE
hot-reload

### DIFF
--- a/src/nc.c
+++ b/src/nc.c
@@ -300,6 +300,7 @@ nc_set_default_options(struct instance *nci)
     nci->pid = (pid_t)-1;
     nci->pid_filename = NULL;
     nci->pidfile = 0;
+    nci->argv = NULL;
 }
 
 static rstatus_t
@@ -525,9 +526,16 @@ nc_run(struct instance *nci)
         return;
     }
 
+    core_cleanup_inherited_socket();
+
     /* run rabbit run */
     for (;;) {
         status = core_loop(ctx);
+        if (status != NC_OK) {
+            break;
+        }
+
+        status = signal_check(nci);
         if (status != NC_OK) {
             break;
         }
@@ -543,6 +551,7 @@ main(int argc, char **argv)
     struct instance nci;
 
     nc_set_default_options(&nci);
+    nci.argv = argv;
 
     status = nc_get_options(argc, argv, &nci);
     if (status != NC_OK) {

--- a/src/nc_client.c
+++ b/src/nc_client.c
@@ -179,6 +179,12 @@ client_close(struct context *ctx, struct conn *conn)
 
     conn->unref(conn);
 
+    status = event_del_conn(ctx->evb, conn);
+    if (status < 0) {
+        log_error("event del conn c %d failed, ignored: %s", conn->sd,
+                  strerror(errno));
+    }
+
     status = close(conn->sd);
     if (status < 0) {
         log_error("close c %d failed, ignored: %s", conn->sd, strerror(errno));

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -17,6 +17,7 @@
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <netdb.h>
 #include <nc_core.h>
 #include <nc_conf.h>
 #include <nc_server.h>
@@ -149,8 +150,8 @@ core_ctx_destroy(struct context *ctx)
     proxy_deinit(ctx);
     server_pool_disconnect(ctx);
     event_base_destroy(ctx->evb);
-    stats_destroy(ctx->stats);
     server_pool_deinit(&ctx->pool);
+    stats_destroy(ctx->stats);
     conf_destroy(ctx->cf);
     nc_free(ctx);
 }
@@ -180,10 +181,10 @@ core_start(struct instance *nci)
 void
 core_stop(struct context *ctx)
 {
+    core_ctx_destroy(ctx);
     conn_deinit();
     msg_deinit();
     mbuf_deinit();
-    core_ctx_destroy(ctx);
 }
 
 static rstatus_t
@@ -360,3 +361,136 @@ core_loop(struct context *ctx)
 
     return NC_OK;
 }
+
+rstatus_t
+core_exec_new_binary(struct instance *nci)
+{
+    int32_t size, len;
+    uint32_t i;
+    char *envp[] = { NULL, NULL };
+    char *fds = NULL;
+    struct context *ctx = nci->ctx;
+    struct array *pool = &(ctx->pool);
+
+    /*
+     * 1. fork
+     */
+    int pid = fork();
+
+    switch (pid) {
+    case -1:
+        log_debug(LOG_WARN, "fork in core_exec_new_binary got error");
+        return NC_ERROR;
+
+    case 0: /* child */
+        break;
+
+    default: /* parent */
+        return NC_OK;
+    }
+
+    /* this is in child if we got here */
+
+    /*
+     * 2. put all listen fds to NC_ENV_FDS:
+     *    NC_ENV_FDS=4;5;10;12;
+     */
+    size = (int32_t)(sizeof(NC_ENV_FDS) + (1 + array_n(pool)) * (1 + NC_UINT32_MAXLEN));
+    len = 0;
+
+    fds = nc_alloc(size);
+    if (fds == NULL) {
+        return NC_ENOMEM;
+    }
+
+    len += nc_scnprintf(fds + len, size - len, NC_ENV_FDS "=");
+    len += nc_scnprintf(fds + len, size - len, "%u;", ctx->stats->sd);
+
+    for (i = 0; i < array_n(pool); i++) {
+        struct server_pool *p = array_get(pool, i);
+        int sd = p->p_conn->sd;
+        if (sd <= 0) {
+            continue;
+        }
+        len += nc_scnprintf(fds + len, size - len, "%u;", sd);
+    }
+    fds[len] = '\0';
+
+    log_debug(LOG_NOTICE, "exec new binary with env: %s", fds);
+
+    /*
+     * 3. exec
+     */
+    envp[0] = fds;
+    execve(nci->argv[0], nci->argv, envp);
+
+    nc_free(fds);  /* actually this is not needed */
+    return NC_OK;
+}
+
+int
+core_inherited_socket(char *listen_address)
+{
+    int sock = 0;
+    char *inherited;
+    char *p, *q;
+    /* we will use nc_unresolve_desc and overwrite input listen_address */
+    char address[NI_MAXHOST + NI_MAXSERV];
+
+    inherited = getenv(NC_ENV_FDS);
+    if (inherited == NULL) {
+        /* not found */
+        return 0;
+    }
+
+    strncpy(address, listen_address, sizeof(address));
+
+    log_debug(LOG_INFO, "trying to get inherited socket '%s' from '%s'",
+              address, inherited);
+
+    for (p = inherited, q = inherited; *p; p++) {
+        if (*p == ';') {
+            sock = nc_atoi(q, p - q);
+
+            if (strcmp(address, nc_unresolve_desc(sock)) == 0) {
+                log_debug(LOG_INFO, "get inherited socket %d for '%s' from '%s'",
+                          sock, address, inherited);
+                sock = dup(sock);
+                log_debug(LOG_INFO, "dup inherited socket as %d", sock);
+
+                return sock;
+            }
+
+            q = p + 1;
+        }
+    }
+
+    log_debug(LOG_INFO, "can not inherited socket '%s'", address);
+    return 0;
+}
+
+/*
+ * all fd we want is already be copied with dup()
+ * so we can close all fd in NC_ENV_FDS
+ * */
+void
+core_cleanup_inherited_socket(void)
+{
+    int sock = 0;
+    char *inherited;
+    char *p, *q;
+
+    inherited = getenv(NC_ENV_FDS);
+    if (inherited == NULL) {
+        return;
+    }
+
+    for (p = inherited, q = inherited; *p; p++) {
+        if (*p == ';') {
+            sock = nc_atoi(q, p - q);
+            close(sock);
+            q = p + 1;
+        }
+    }
+}
+

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -66,6 +66,9 @@
 /* reserved fds for std streams, log, stats fd, epoll etc. */
 #define RESERVED_FDS 32
 
+/* EVN name for inherit fd */
+#define NC_ENV_FDS "NC_ENV_FDS"
+
 typedef int rstatus_t; /* return type */
 typedef int err_t;     /* error type */
 
@@ -96,6 +99,7 @@ struct event_base;
 #include <limits.h>
 #include <time.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <pthread.h>
 
 #include <sys/types.h>
@@ -117,6 +121,7 @@ struct event_base;
 #include <nc_message.h>
 #include <nc_connection.h>
 #include <nc_server.h>
+#include <nc_proxy.h>
 
 struct context {
     uint32_t           id;          /* unique context id */
@@ -147,11 +152,16 @@ struct instance {
     pid_t           pid;                         /* process id */
     char            *pid_filename;               /* pid filename */
     unsigned        pidfile:1;                   /* pid file created? */
+    char            **argv;                      /* argv of main() */
 };
 
 struct context *core_start(struct instance *nci);
 void core_stop(struct context *ctx);
 rstatus_t core_core(void *arg, uint32_t events);
 rstatus_t core_loop(struct context *ctx);
+
+rstatus_t core_exec_new_binary(struct instance *nci);
+int core_inherited_socket(char *listen_address);
+void core_cleanup_inherited_socket(void);
 
 #endif

--- a/src/nc_log.c
+++ b/src/nc_log.c
@@ -36,7 +36,7 @@ log_init(int level, char *name)
     if (name == NULL || !strlen(name)) {
         l->fd = STDERR_FILENO;
     } else {
-        l->fd = open(name, O_WRONLY | O_APPEND | O_CREAT, 0644);
+        l->fd = open(name, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0644);
         if (l->fd < 0) {
             log_stderr("opening log file '%s' failed: %s", name,
                        strerror(errno));
@@ -66,7 +66,7 @@ log_reopen(void)
 
     if (l->fd != STDERR_FILENO) {
         close(l->fd);
-        l->fd = open(l->name, O_WRONLY | O_APPEND | O_CREAT, 0644);
+        l->fd = open(l->name, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0644);
         if (l->fd < 0) {
             log_stderr_safe("reopening log file '%s' failed, ignored: %s", l->name,
                        strerror(errno));
@@ -150,7 +150,7 @@ _log(const char *file, int line, int panic, const char *fmt, ...)
     buf[len++] = '[';
     len += nc_strftime(buf + len, size - len, "%Y-%m-%d %H:%M:%S.", localtime(&tv.tv_sec));
     len += nc_scnprintf(buf + len, size - len, "%03ld", tv.tv_usec/1000);
-    len += nc_scnprintf(buf + len, size - len, "] %s:%d ", file, line);
+    len += nc_scnprintf(buf + len, size - len, "] [%d] %s:%d ", getpid(), file, line);
 
     va_start(args, fmt);
     len += nc_vscnprintf(buf + len, size - len, fmt, args);

--- a/src/nc_proxy.c
+++ b/src/nc_proxy.c
@@ -79,6 +79,12 @@ proxy_close(struct context *ctx, struct conn *conn)
 
     conn->unref(conn);
 
+    status = event_del_conn(ctx->evb, conn);
+    if (status < 0) {
+        log_error("event del conn p %d failed, ignored: %s", conn->sd,
+                  strerror(errno));
+    }
+
     status = close(conn->sd);
     if (status < 0) {
         log_error("close p %d failed, ignored: %s", conn->sd, strerror(errno));
@@ -162,6 +168,28 @@ proxy_listen(struct context *ctx, struct conn *p)
         return NC_ERROR;
     }
 
+    return NC_OK;
+}
+
+static rstatus_t
+proxy_inherited_listen(struct context *ctx, struct conn *p)
+{
+    rstatus_t status;
+    int fd;
+    struct server_pool *pool = p->owner;
+
+    ASSERT(p->proxy);
+
+    fd = core_inherited_socket(nc_unresolve_addr(p->addr, p->addrlen));
+    if (fd > 0) {
+        p->sd = fd;
+    } else {
+        status = proxy_listen(ctx, p);
+        if (status != NC_OK) {
+            return status;
+        }
+    }
+
     status = event_add_conn(ctx->evb, p);
     if (status < 0) {
         log_error("event add conn p %d on addr '%.*s' failed: %s",
@@ -193,7 +221,7 @@ proxy_each_init(void *elem, void *data)
         return NC_ENOMEM;
     }
 
-    status = proxy_listen(pool->ctx, p);
+    status = proxy_inherited_listen(pool->ctx, p);
     if (status != NC_OK) {
         p->close(pool->ctx, p);
         return status;
@@ -282,7 +310,7 @@ proxy_accept(struct context *ctx, struct conn *p)
                 return NC_OK;
             }
 
-            /* 
+            /*
              * Workaround of https://github.com/twitter/twemproxy/issues/97
              *
              * We should never reach here because the check for conn_ncurr_cconn()
@@ -345,6 +373,15 @@ proxy_accept(struct context *ctx, struct conn *p)
         c->close(ctx, c);
         return status;
     }
+
+    status = fcntl(c->sd, F_SETFD, FD_CLOEXEC);
+    if (status < 0) {
+        log_error("fcntl FD_CLOEXEC on c %d from p %d failed: %s",
+                  c->sd, p->sd, strerror(errno));
+        c->close(ctx, c);
+        return status;
+    }
+
 
     if (p->family == AF_INET || p->family == AF_INET6) {
         status = nc_set_tcpnodelay(c->sd);

--- a/src/nc_signal.h
+++ b/src/nc_signal.h
@@ -30,5 +30,6 @@ struct signal {
 rstatus_t signal_init(void);
 void signal_deinit(void);
 void signal_handler(int signo);
+rstatus_t signal_check(struct instance *nci);
 
 #endif

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -816,10 +816,17 @@ stats_listen(struct stats *st)
 {
     rstatus_t status;
     struct sockinfo si;
+    int sd;
 
     status = nc_resolve(&st->addr, st->port, &si);
     if (status < 0) {
         return status;
+    }
+
+    sd = core_inherited_socket(nc_unresolve_addr((struct sockaddr *)&si.addr, si.addrlen));
+    if (sd > 0) {
+        st->sd = sd;
+        return NC_OK;
     }
 
     st->sd = socket(si.family, SOCK_STREAM, 0);

--- a/src/nc_util.h
+++ b/src/nc_util.h
@@ -73,10 +73,10 @@
  * invoking system calls.
  */
 #define nc_gethostname(_name, _len) \
-    gethostname((char *)_name, (size_t)_len)
+    gethostname((char *)_name, (size_t)(_len))
 
 #define nc_atoi(_line, _n)          \
-    _nc_atoi((uint8_t *)_line, (size_t)_n)
+    _nc_atoi((uint8_t *)_line, (size_t)(_n))
 
 int nc_set_blocking(int sd);
 int nc_set_nonblocking(int sd);


### PR DESCRIPTION
how it works:
1. when we receive USR1 signale, we will fork and exec with new binary and new config.
2. the new process will inherited all listen-socket from the old process, including:
   - stat socket
   - listen socket for each pool
3. after the new process is already running, the old process will close all listen socket.
   and wait for 3 seconds (for those who has already connected with old process)
   3 seconds later, it close all client socket and shut down
   
   (however, the keep-alive connectin will be closed, we can not wait forever)

TODO:
- make it work for `unix domain socket`
- need test on nc_kqueue

test cases:

https://github.com/idning/test-twemproxy/blob/master/test_system/test_reload.py
