### PR TITLE
update distribution tarball links to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## Build
 
-To build nutcracker from [distribution tarball](http://code.google.com/p/twemproxy/downloads/list):
+To build nutcracker from [distribution tarball](https://github.com/twitter/twemproxy/releases):
 
     $ ./configure
     $ make
     $ sudo make install
 
-To build nutcracker from [distribution tarball](http://code.google.com/p/twemproxy/downloads/list) in _debug mode_:
+To build nutcracker from [distribution tarball](https://github.com/twitter/twemproxy/releases) in _debug mode_:
 
     $ CFLAGS="-ggdb3 -O0" ./configure --enable-debug=full
     $ make


### PR DESCRIPTION
distribution tarball links were pointed to code.google, which doesnt contain current releases....
