### PR TITLE
Adds init script for debian servers

### DIFF
--- a/scripts/nutcracker.init.debian
+++ b/scripts/nutcracker.init.debian
@@ -5,7 +5,7 @@
 # Required-Stop:     $network $remote_fs $local_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Stop/start nutcracker nutcracker
+# Short-Description: Stop/start nutcracker
 ### END INIT INFO
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin


### PR DESCRIPTION
Currently twemproxy only provides init script for red hat based systems.
