### PR TITLE
[IMPROVEMENT] reducing memory allocating for sub_msgs

### DIFF
--- a/src/proto/Makefile.am
+++ b/src/proto/Makefile.am
@@ -11,4 +11,5 @@ noinst_HEADERS = nc_proto.h
 
 libproto_a_SOURCES =			\
 	nc_memcache.c			\
-	nc_redis.c
+	nc_redis.c \
+	nc_proto_util.c

--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -1206,7 +1206,7 @@ memcache_fragment_retrieval(struct msg *r, uint32_t ncontinuum,
     uint32_t i;
     rstatus_t status;
 
-    sub_msgs = nc_zalloc(ncontinuum * sizeof(*sub_msgs));
+    sub_msgs = get_sub_msgs(ncontinuum);
     if (sub_msgs == NULL) {
         return NC_ENOMEM;
     }
@@ -1214,7 +1214,6 @@ memcache_fragment_retrieval(struct msg *r, uint32_t ncontinuum,
     ASSERT(r->frag_seq == NULL);
     r->frag_seq = nc_alloc(array_n(r->keys) * sizeof(*r->frag_seq));
     if (r->frag_seq == NULL) {
-        nc_free(sub_msgs);
         return NC_ENOMEM;
     }
 
@@ -1244,7 +1243,6 @@ memcache_fragment_retrieval(struct msg *r, uint32_t ncontinuum,
         if (sub_msgs[idx] == NULL) {
             sub_msgs[idx] = msg_get(r->owner, r->request, r->redis);
             if (sub_msgs[idx] == NULL) {
-                nc_free(sub_msgs);
                 return NC_ENOMEM;
             }
         }
@@ -1253,7 +1251,6 @@ memcache_fragment_retrieval(struct msg *r, uint32_t ncontinuum,
         sub_msg->narg++;
         status = memcache_append_key(sub_msg, kpos->start, kpos->end - kpos->start);
         if (status != NC_OK) {
-            nc_free(sub_msgs);
             return status;
         }
     }
@@ -1271,14 +1268,12 @@ memcache_fragment_retrieval(struct msg *r, uint32_t ncontinuum,
             status = msg_prepend(sub_msg, (uint8_t *)"gets ", 5);
         }
         if (status != NC_OK) {
-            nc_free(sub_msgs);
             return status;
         }
 
         /* append \r\n */
         status = msg_append(sub_msg, (uint8_t *)CRLF, CRLF_LEN);
         if (status != NC_OK) {
-            nc_free(sub_msgs);
             return status;
         }
 
@@ -1290,7 +1285,6 @@ memcache_fragment_retrieval(struct msg *r, uint32_t ncontinuum,
         r->nfrag++;
     }
 
-    nc_free(sub_msgs);
     return NC_OK;
 }
 

--- a/src/proto/nc_proto.h
+++ b/src/proto/nc_proto.h
@@ -154,4 +154,5 @@ rstatus_t redis_add_auth_packet(struct context *ctx, struct conn *c_conn, struct
 rstatus_t redis_fragment(struct msg *r, uint32_t ncontinuum, struct msg_tqh *frag_msgq);
 rstatus_t redis_reply(struct msg *r);
 
+struct msg **get_sub_msgs(uint32_t ncontinuum);
 #endif

--- a/src/proto/nc_proto_util.c
+++ b/src/proto/nc_proto_util.c
@@ -1,0 +1,45 @@
+/*
+ * twemproxy - A fast and lightweight proxy for memcached protocol.
+ * Copyright (C) 2011 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <ctype.h>
+
+#include <nc_core.h>
+#include <nc_proto.h>
+
+#define MINIMUM_SUB_MSGS_SIZE 4096
+
+struct msg **get_sub_msgs(uint32_t ncontinuum) {
+    static uint32_t min_size = MINIMUM_SUB_MSGS_SIZE;
+    static struct msg *origin[MINIMUM_SUB_MSGS_SIZE];
+    static struct msg **sub_msgs = origin;
+
+    if (ncontinuum > min_size) {
+        if (sub_msgs == origin) {
+            sub_msgs = nc_alloc(ncontinuum * sizeof(struct msg *));
+        } else {
+            sub_msgs = nc_realloc(sub_msgs, ncontinuum * sizeof(struct msg *));
+        }
+        min_size = ncontinuum;
+    }
+
+    if (sub_msgs) {
+        memset(sub_msgs, 0, ncontinuum * sizeof(struct msg *));
+    }
+
+    return sub_msgs;
+}


### PR DESCRIPTION
twemproxy is single thread.
so, we can remove memory allocating when client calls "MGET" or "DELETE"
we can reduce memory allocating.
