### PR TITLE
change verbosity option to verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Few checklists:
       -t, --test-conf        : test configuration for syntax errors and exit
       -d, --daemonize        : run as a daemon
       -D, --describe-stats   : print stats description and exit
-      -v, --verbosity=N      : set logging level (default: 5, min: 0, max: 11)
+      -v, --verbose=N        : set logging level (default: 5, min: 0, max: 11)
       -o, --output=S         : set logging file (default: stderr)
       -c, --conf-file=S      : set configuration file (default: conf/nutcracker.yml)
       -s, --stats-port=N     : set stats monitoring port (default: 22222)

--- a/man/nutcracker.8
+++ b/man/nutcracker.8
@@ -39,7 +39,7 @@ Test configuration for syntax errors and exit.
 .BR \-D ", " \-\-describe-stats
 Print stats description and exit.
 .TP
-.BR \-v ", " \-\-verbosity=\fIN\fP
+.BR \-v ", " \-\-verbose=\fIN\fP
 Set logging level to \fIN\fP. (default: 5, min: 0, max: 11)
 .TP
 .BR \-o ", " \-\-output=\fIfilename\fP

--- a/notes/recommendation.md
+++ b/notes/recommendation.md
@@ -2,7 +2,7 @@ If you are deploying nutcracker in your production environment, here are a few r
 
 ## Log Level
 
-By default debug logging is disabled in nutcracker. However, it is worthwhile running nutcracker with debug logging enabled and verbosity level set to LOG_INFO (-v 6 or --verbosity=6). This in reality does not add much overhead as you only pay the cost of checking an if condition for every log line encountered during the run time.
+By default debug logging is disabled in nutcracker. However, it is worthwhile running nutcracker with debug logging enabled and verbosity level set to LOG_INFO (-v 6 or --verbose=6). This in reality does not add much overhead as you only pay the cost of checking an if condition for every log line encountered during the run time.
 
 At LOG_INFO level, nutcracker logs the life cycle of every client and server connection and important events like the server being ejected from the hash ring and so on. Eg.
 

--- a/src/nc.c
+++ b/src/nc.c
@@ -214,7 +214,7 @@ nc_show_usage(void)
         "  -d, --daemonize        : run as a daemon" CRLF
         "  -D, --describe-stats   : print stats description and exit");
     log_stderr(
-        "  -v, --verbosity=N      : set logging level (default: %d, min: %d, max: %d)" CRLF
+        "  -v, --verbose=N        : set logging level (default: %d, min: %d, max: %d)" CRLF
         "  -o, --output=S         : set logging file (default: %s)" CRLF
         "  -c, --conf-file=S      : set configuration file (default: %s)" CRLF
         "  -s, --stats-port=N     : set stats monitoring port (default: %d)" CRLF


### PR DESCRIPTION
refer: https://github.com/twitter/twemproxy/issues/288

I think it is better to change option name from verbosity to verbose.
What do you think? @idning, @manjuraj 
because, users already are using -v or --verbose even though it is not printed.
