### PR TITLE
Build support for freebsd 10 (adding libexecinfo)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,7 @@ AS_IF([test "x$ac_cv_epoll_works" = "xno" &&
 AM_CONDITIONAL([OS_LINUX], [test "x$ac_cv_epoll_works" = "xyes"])
 AM_CONDITIONAL([OS_BSD], [test "x$ac_cv_kqueue_works" = "xyes"])
 AM_CONDITIONAL([OS_SOLARIS], [test "x$ac_cv_evports_works" = "xyes"])
+AM_CONDITIONAL([OS_FREEBSD], [test "$(uname -v | cut -c 1-10)" == "FreeBSD 10"])
 
 # Package options
 AC_MSG_CHECKING([whether to enable debug logs and asserts])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,9 @@ AM_LDFLAGS += -lm -lpthread -rdynamic
 if OS_SOLARIS
 AM_LDFLAGS += -lnsl -lsocket
 endif
+if OS_FREEBSD
+AM_LDFLAGS += -lexecinfo
+endif
 
 SUBDIRS = hashkit proto event
 


### PR DESCRIPTION
Building on FreeBSD 10 failed because of a missing linker dependency to libexecinfo.
Note that this fix explicitly targets FreeBSD 10 as future version might have different dependencies.
FreeBSD 9 does not require this fix.
