### PR TITLE
Allow file permissions to be set for UNIX domain listening socket

### DIFF
--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -59,6 +59,7 @@ struct conf_listen {
     struct string   pname;   /* listen: as "name:port" */
     struct string   name;    /* name */
     int             port;    /* port */
+    mode_t          perm;    /* socket permissions */
     struct sockinfo info;    /* listen socket info */
     unsigned        valid:1; /* valid? */
 };

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -107,6 +107,7 @@ struct server_pool {
     int                family;               /* socket family */
     socklen_t          addrlen;              /* socket length */
     struct sockaddr    *addr;                /* socket address (ref in conf_pool) */
+    mode_t             perm;                 /* socket permission */
     int                dist_type;            /* distribution type (dist_type_t) */
     int                key_hash_type;        /* key hash type (hash_type_t) */
     hash_t             key_hash;             /* key hasher */


### PR DESCRIPTION
When 'listen:' starts with a slash, it is interpreted as a UNIX domain socket
path for twemproxy to bind. This patch allows file permissions for the socket
to be specified via a space-separated permission field following the path.

Examples:

Permissions not set, so use defaults (same as before, still supported):

    listen: /var/run/nutcracker/nutcracker.sock

Set socket permissions to ugo+rw:

    listen: /var/run/nutcracker/nutcracker.sock 0666