### PR TITLE
hashkit: Add correct fnv1* implementations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,14 @@ nutcracker can be configured through a YAML file specified by the -c or --conf-f
  + crc16
  + crc32 (crc32 implementation compatible with [libmemcached](http://libmemcached.org/))
  + crc32a (correct crc32 implementation as per the spec)
- + fnv1_64
+ + fnv1_64 (fnv\* implementations compatible with [libmemcached](http://libmemcached.org/), same below)
  + fnv1a_64
  + fnv1_32
  + fnv1a_32
+ + fnv1_64a (correct fnv\* implementations as per the spec, same below)
+ + fnv1a_64a
+ + fnv1_32a
+ + fnv1a_32a
  + hsieh
  + murmur
  + jenkins

--- a/src/hashkit/nc_fnv.c
+++ b/src/hashkit/nc_fnv.c
@@ -22,6 +22,11 @@ static uint64_t FNV_64_PRIME = UINT64_C(0x100000001b3);
 static uint32_t FNV_32_INIT = 2166136261UL;
 static uint32_t FNV_32_PRIME = 16777619;
 
+
+/*
+ * fnv* implementations compatible with libmemcached library. Unfortunately
+ * these implementations do not return fnv* as per spec.
+ */
 uint32_t
 hash_fnv1_64(const char *key, size_t key_length)
 {
@@ -74,6 +79,74 @@ hash_fnv1a_32(const char *key, size_t key_length)
 
     for (x= 0; x < key_length; x++) {
       uint32_t val = (uint32_t)key[x];
+      hash ^= val;
+      hash *= FNV_32_PRIME;
+    }
+
+    return hash;
+}
+
+
+/*
+ * correct fnv\* implementations as per the spec.
+ */
+
+uint32_t
+hash_fnv1_64a(const char *key, size_t key_length)
+{
+    uint64_t hash = FNV_64_INIT;
+    size_t x;
+    const uint8_t* unsigned_key = (uint8_t*)key;
+
+    for (x = 0; x < key_length; x++) {
+      hash *= FNV_64_PRIME;
+      hash ^= (uint64_t)unsigned_key[x];
+    }
+
+    return (uint32_t)hash;
+}
+
+uint32_t
+hash_fnv1a_64a(const char *key, size_t key_length)
+{
+    uint32_t hash = (uint32_t) FNV_64_INIT;
+    size_t x;
+    const uint8_t* unsigned_key = (uint8_t*)key;
+
+    for (x = 0; x < key_length; x++) {
+      uint32_t val = (uint32_t)unsigned_key[x];
+      hash ^= val;
+      hash *= (uint32_t) FNV_64_PRIME;
+    }
+
+    return hash;
+}
+
+uint32_t
+hash_fnv1_32a(const char *key, size_t key_length)
+{
+    uint32_t hash = FNV_32_INIT;
+    size_t x;
+    const uint8_t* unsigned_key = (uint8_t*)key;
+
+    for (x = 0; x < key_length; x++) {
+      uint32_t val = (uint32_t)unsigned_key[x];
+      hash *= FNV_32_PRIME;
+      hash ^= val;
+    }
+
+    return hash;
+}
+
+uint32_t
+hash_fnv1a_32a(const char *key, size_t key_length)
+{
+    uint32_t hash = FNV_32_INIT;
+    size_t x;
+    const uint8_t* unsigned_key = (uint8_t*)key;
+
+    for (x= 0; x < key_length; x++) {
+      uint32_t val = (uint32_t)unsigned_key[x];
       hash ^= val;
       hash *= FNV_32_PRIME;
     }

--- a/src/hashkit/nc_fnv.c
+++ b/src/hashkit/nc_fnv.c
@@ -34,8 +34,9 @@ hash_fnv1_64(const char *key, size_t key_length)
     size_t x;
 
     for (x = 0; x < key_length; x++) {
+      uint64_t val = (uint64_t)key[x];
       hash *= FNV_64_PRIME;
-      hash ^= (uint64_t)key[x];
+      hash ^= val;
     }
 
     return (uint32_t)hash;
@@ -44,7 +45,7 @@ hash_fnv1_64(const char *key, size_t key_length)
 uint32_t
 hash_fnv1a_64(const char *key, size_t key_length)
 {
-    uint32_t hash = (uint32_t) FNV_64_INIT;
+    uint32_t hash = (uint32_t) FNV_64_INIT; // buggy!!!
     size_t x;
 
     for (x = 0; x < key_length; x++) {
@@ -99,8 +100,9 @@ hash_fnv1_64a(const char *key, size_t key_length)
     const uint8_t* unsigned_key = (uint8_t*)key;
 
     for (x = 0; x < key_length; x++) {
+      uint64_t val = (uint64_t)unsigned_key[x];
       hash *= FNV_64_PRIME;
-      hash ^= (uint64_t)unsigned_key[x];
+      hash ^= val;
     }
 
     return (uint32_t)hash;
@@ -109,14 +111,14 @@ hash_fnv1_64a(const char *key, size_t key_length)
 uint32_t
 hash_fnv1a_64a(const char *key, size_t key_length)
 {
-    uint32_t hash = (uint32_t) FNV_64_INIT;
+    uint64_t hash = FNV_64_INIT;
     size_t x;
     const uint8_t* unsigned_key = (uint8_t*)key;
 
     for (x = 0; x < key_length; x++) {
-      uint32_t val = (uint32_t)unsigned_key[x];
+      uint64_t val = (uint64_t)unsigned_key[x];
       hash ^= val;
-      hash *= (uint32_t) FNV_64_PRIME;
+      hash *= FNV_64_PRIME;
     }
 
     return hash;

--- a/src/hashkit/nc_hashkit.h
+++ b/src/hashkit/nc_hashkit.h
@@ -31,6 +31,10 @@
     ACTION( HASH_FNV1A_64,      fnv1a_64      ) \
     ACTION( HASH_FNV1_32,       fnv1_32       ) \
     ACTION( HASH_FNV1A_32,      fnv1a_32      ) \
+    ACTION( HASH_FNV1_64A,      fnv1_64a      ) \
+    ACTION( HASH_FNV1A_64A,     fnv1a_64a     ) \
+    ACTION( HASH_FNV1_32A,      fnv1_32a      ) \
+    ACTION( HASH_FNV1A_32A,     fnv1a_32a     ) \
     ACTION( HASH_HSIEH,         hsieh         ) \
     ACTION( HASH_MURMUR,        murmur        ) \
     ACTION( HASH_JENKINS,       jenkins       ) \
@@ -64,6 +68,10 @@ uint32_t hash_fnv1_64(const char *key, size_t key_length);
 uint32_t hash_fnv1a_64(const char *key, size_t key_length);
 uint32_t hash_fnv1_32(const char *key, size_t key_length);
 uint32_t hash_fnv1a_32(const char *key, size_t key_length);
+uint32_t hash_fnv1_64a(const char *key, size_t key_length);
+uint32_t hash_fnv1a_64a(const char *key, size_t key_length);
+uint32_t hash_fnv1_32a(const char *key, size_t key_length);
+uint32_t hash_fnv1a_32a(const char *key, size_t key_length);
 uint32_t hash_hsieh(const char *key, size_t key_length);
 uint32_t hash_jenkins(const char *key, size_t length);
 uint32_t hash_murmur(const char *key, size_t length);


### PR DESCRIPTION
Old fnv1\* implementations(fnv1_64/fnv1a_64/fnv1_32/fnv1a_32) are not correct as per spec but are compatible with libmemcachd. The corresponding correct implementations are fnv1_64a/fnv1a_64a/fnv1_32a/fnv1a_32a.

~~This issue is similar to 653b05f861ae3ce0ff143e1067af378f677a4d29 (@manjuraj).~~

http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function says:

```
The XOR is an 8-bit operation that modifies only the lower 8-bits of the hash value.
```

Suppose key is a utf-8 encoded string `"\xe4\xb8\xad"`(Chinese Character`中` in UTF-8). Let's take `\xe4`(`0xe4 >= 0b10000000`) as an example:

``` c
(uint32_t)(char)0xe4 = 4294967268 // buggy
(uint32_t)(uint8_t)(char)0xe4 = 228 // correct
(uint32_t)(unsigned char)(char)0xe4 = 228 // also correct
```

cc @windreamer
