### PR TITLE
Fix SORT command to support arguments

### DIFF
--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -61,7 +61,6 @@ redis_arg0(struct msg *r)
     case MSG_REQ_REDIS_EXISTS:
     case MSG_REQ_REDIS_PERSIST:
     case MSG_REQ_REDIS_PTTL:
-    case MSG_REQ_REDIS_SORT:
     case MSG_REQ_REDIS_TTL:
     case MSG_REQ_REDIS_TYPE:
     case MSG_REQ_REDIS_DUMP:
@@ -209,6 +208,8 @@ redis_argn(struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_BITCOUNT:
+
+    case MSG_REQ_REDIS_SORT:
 
     case MSG_REQ_REDIS_SET:
     case MSG_REQ_REDIS_HDEL:


### PR DESCRIPTION
First of all, my apologies because it was me who introduced this bug.

I sent a PR adding support for SORT command but it was wrong and it wasn't accepting arguments (so it was totally useless). This PR solves this issue.