### PR TITLE
twemproxy work with redis-sentinel

### DIFF
--- a/conf/nutcracker.yml
+++ b/conf/nutcracker.yml
@@ -65,3 +65,18 @@ omega:
   servers:
    - 127.0.0.1:11214:100000
    - 127.0.0.1:11215:1
+
+sigma:
+  listen: 127.0.0.1:22125
+  hash: fnv1a_64
+  distribution: ketama
+  auto_eject_hosts: false
+  redis: true
+  server_retry_timeout: 2000
+  server_failure_limit: 1
+  servers:
+    - 127.0.0.1:6379:1 server1
+    - 127.0.0.1:6380:1 server2
+  sentinels:
+    - 127.0.0.1:26379:1
+    - 127.0.0.1:26380:1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,6 +38,7 @@ nutcracker_SOURCES =			\
 	nc_connection.c nc_connection.h	\
 	nc_client.c nc_client.h		\
 	nc_server.c nc_server.h		\
+	nc_sentinel.c nc_sentinel.h	\
 	nc_proxy.c nc_proxy.h		\
 	nc_message.c nc_message.h	\
 	nc_request.c			\

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -284,6 +284,8 @@ conf_pool_each_transform(void *elem, void *data)
     sp->continuum = NULL;
     sp->nlive_server = 0;
     sp->next_rebuild = 0LL;
+    sp->next_sentinel_reconn = 0LL;
+    sp->sentinel_idx = 0;
 
     sp->name = cp->name;
     sp->addrstr = cp->listen.pname;

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -168,6 +168,9 @@ conf_server_each_transform(void *elem, void *data)
     s->next_retry = 0LL;
     s->failure_count = 0;
 
+    /* proxy will set sentinel flag after server transform */
+    s->sentinel = 0;
+
     log_debug(LOG_VERB, "transform to server %"PRIu32" '%.*s'",
               s->idx, s->pname.len, s->pname.data);
 
@@ -310,12 +313,12 @@ conf_pool_each_transform(void *elem, void *data)
     sp->auto_eject_hosts = cp->auto_eject_hosts ? 1 : 0;
     sp->preconnect = cp->preconnect ? 1 : 0;
 
-    status = server_init(&sp->server, &cp->server, sp);
+    status = server_init(&sp->server, &cp->server, sp, false);
     if (status != NC_OK) {
         return status;
     }
 
-    status = server_init(&sp->sentinel, &cp->sentinel, sp);
+    status = server_init(&sp->sentinel, &cp->sentinel, sp, true);
     if (status != NC_OK) {
         return status;
     }

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -284,7 +284,7 @@ conf_pool_each_transform(void *elem, void *data)
     sp->continuum = NULL;
     sp->nlive_server = 0;
     sp->next_rebuild = 0LL;
-    sp->next_sentinel_reconn = 0LL;
+    sp->next_sentinel_connect = 0LL;
     sp->sentinel_idx = 0;
 
     sp->name = cp->name;

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -151,6 +151,7 @@ conf_server_each_transform(void *elem, void *data)
 
     s->idx = array_idx(server, s);
     s->owner = NULL;
+    s->conf_server = cs;
 
     s->pname = cs->pname;
     s->name = cs->name;
@@ -493,18 +494,20 @@ conf_rewrite(struct context *ctx)
         }
 
         nserver = array_n(&cp->sentinel);
-        conf_write(fh, "  sentinels:");
+        if (nserver) {
+            conf_write(fh, "  sentinels:");
 
-        for (j = 0; j < nserver; j++) {
-            cs = array_get(&cp->sentinel, j);
-            if (cs->name.len >= cs->pname.len
-                    || nc_strncmp(cs->pname.data, cs->name.data, cs->name.len)) {
-                conf_write(fh, "   - %.*s %.*s",
-                        cs->pname.len, cs->pname.data,
-                        cs->name.len, cs->name.data);
-            } else {
-                conf_write(fh, "   - %.*s",
-                        cs->pname.len, cs->pname.data);
+            for (j = 0; j < nserver; j++) {
+                cs = array_get(&cp->sentinel, j);
+                if (cs->name.len >= cs->pname.len
+                        || nc_strncmp(cs->pname.data, cs->name.data, cs->name.len)) {
+                    conf_write(fh, "   - %.*s %.*s",
+                            cs->pname.len, cs->pname.data,
+                            cs->name.len, cs->name.data);
+                } else {
+                    conf_write(fh, "   - %.*s",
+                            cs->pname.len, cs->pname.data);
+                }
             }
         }
 

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -32,9 +32,12 @@
 #define CONF_ROOT_DEPTH     1
 #define CONF_MAX_DEPTH      CONF_ROOT_DEPTH + 1
 
+#define CONF_MAX_SEQ        2
+
 #define CONF_DEFAULT_ARGS       3
 #define CONF_DEFAULT_POOL       8
 #define CONF_DEFAULT_SERVERS    8
+#define CONF_DEFAULT_SENTINELS  5
 
 #define CONF_UNSET_NUM  -1
 #define CONF_UNSET_PTR  NULL
@@ -91,6 +94,7 @@ struct conf_pool {
     int                server_retry_timeout;  /* server_retry_timeout: in msec */
     int                server_failure_limit;  /* server_failure_limit: */
     struct array       server;                /* servers: conf_server[] */
+    struct array       sentinel;              /* sentinels: conf_server[] */
     unsigned           valid:1;               /* valid? */
 };
 

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -138,5 +138,6 @@ rstatus_t conf_pool_each_transform(void *elem, void *data);
 
 struct conf *conf_create(char *filename);
 void conf_destroy(struct conf *cf);
+void conf_rewrite(struct context *ctx);
 
 #endif

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -152,13 +152,14 @@ _conn_get(void)
 
     conn->client = 0;
     conn->proxy = 0;
-    conn->sentinel = 0;
     conn->connecting = 0;
     conn->connected = 0;
     conn->eof = 0;
     conn->done = 0;
     conn->redis = 0;
     conn->need_auth = 0;
+
+    conn->status = CONN_DISCONNECTED;
 
     ntotal_conn++;
     ncurr_conn++;
@@ -229,13 +230,21 @@ conn_get(void *owner, bool client, bool redis)
 
         conn->recv = msg_recv;
         conn->recv_next = rsp_recv_next;
-        conn->recv_done = rsp_recv_done;
+        if (server->sentinel) {
+            conn->recv_done = sentinel_recv_done;
+        } else {
+            conn->recv_done = rsp_recv_done;
+        }
 
         conn->send = msg_send;
         conn->send_next = req_send_next;
         conn->send_done = req_send_done;
 
-        conn->close = server_close;
+        if (server->sentinel) {
+            conn->close = sentinel_close;
+        } else {
+            conn->close = server_close;
+        }
         conn->active = server_active;
 
         conn->ref = server_ref;
@@ -258,47 +267,6 @@ conn_get(void *owner, bool client, bool redis)
 
     conn->ref(conn, owner);
     log_debug(LOG_VVERB, "get conn %p client %d", conn, conn->client);
-
-    return conn;
-}
-
-struct conn *
-conn_get_sentinel(void *owner)
-{
-    struct conn *conn;
-
-    conn = _conn_get();
-    if (conn == NULL) {
-        return NULL;
-    }
-
-    conn->redis = 1;
-    conn->client = 0;
-    conn->sentinel = 1;
-    conn->status = CONN_DISCONNECTED;
-
-    conn->recv = msg_recv;
-    conn->recv_next = rsp_recv_next;
-    conn->recv_done = sentinel_recv_done;
-
-    conn->send = msg_send;
-    conn->send_next = req_send_next;
-    conn->send_done = req_send_done;
-
-    conn->close = sentinel_close;
-    conn->active = server_active;
-
-    conn->ref = server_ref;
-    conn->unref = server_unref;
-
-    conn->enqueue_inq = req_server_enqueue_imsgq;
-    conn->dequeue_inq = req_server_dequeue_imsgq;
-    conn->enqueue_outq = req_server_enqueue_omsgq;
-    conn->dequeue_outq = req_server_dequeue_omsgq;
-
-    conn->ref(conn, owner);
-
-    log_debug(LOG_VVERB, "get conn %p sentinel %d", conn, conn->sentinel);
 
     return conn;
 }

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -275,6 +275,7 @@ conn_get_sentinel(void *owner)
     conn->redis = 1;
     conn->client = 0;
     conn->sentinel = 1;
+    conn->status = CONN_DISCONNECTED;
 
     conn->recv = msg_recv;
     conn->recv_next = rsp_recv_next;

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -20,6 +20,14 @@
 
 #include <nc_core.h>
 
+typedef enum conn_status {
+    CONN_DISCONNECTED,
+    CONN_SEND_REQ,
+    CONN_ACK_INFO,
+    CONN_ACK_SWITCH_SUB,
+    CONN_ACK_REDIRECT_SUB,
+} conn_status_t;
+
 typedef rstatus_t (*conn_recv_t)(struct context *, struct conn*);
 typedef struct msg* (*conn_recv_next_t)(struct context *, struct conn *, bool);
 typedef void (*conn_recv_done_t)(struct context *, struct conn *, struct msg *, struct msg *);
@@ -90,6 +98,8 @@ struct conn {
     unsigned            done:1;        /* done? aka close? */
     unsigned            redis:1;       /* redis? */
     unsigned            need_auth:1;   /* need_auth? */
+
+    conn_status_t       status;        /* conn status, just used for sentinel at present */
 };
 
 TAILQ_HEAD(conn_tqh, conn);

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -91,7 +91,6 @@ struct conn {
 
     unsigned            client:1;      /* client? or server? */
     unsigned            proxy:1;       /* proxy? */
-    unsigned            sentinel:1;    /* sentinel? */
     unsigned            connecting:1;  /* connecting? */
     unsigned            connected:1;   /* connected? */
     unsigned            eof:1;         /* eof? aka passive close? */

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -106,7 +106,6 @@ TAILQ_HEAD(conn_tqh, conn);
 struct context *conn_to_ctx(struct conn *conn);
 struct conn *conn_get(void *owner, bool client, bool redis);
 struct conn *conn_get_proxy(void *owner);
-struct conn *conn_get_sentinel(void *owner);
 void conn_put(struct conn *conn);
 ssize_t conn_recv(struct conn *conn, void *buf, size_t size);
 ssize_t conn_sendv(struct conn *conn, struct array *sendv, size_t nsend);

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -83,6 +83,7 @@ struct conn {
 
     unsigned            client:1;      /* client? or server? */
     unsigned            proxy:1;       /* proxy? */
+    unsigned            sentinel:1;    /* sentinel? */
     unsigned            connecting:1;  /* connecting? */
     unsigned            connected:1;   /* connected? */
     unsigned            eof:1;         /* eof? aka passive close? */
@@ -96,6 +97,7 @@ TAILQ_HEAD(conn_tqh, conn);
 struct context *conn_to_ctx(struct conn *conn);
 struct conn *conn_get(void *owner, bool client, bool redis);
 struct conn *conn_get_proxy(void *owner);
+struct conn *conn_get_sentinel(void *owner);
 void conn_put(struct conn *conn);
 ssize_t conn_recv(struct conn *conn, void *buf, size_t size);
 ssize_t conn_sendv(struct conn *conn, struct array *sendv, size_t nsend);

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -113,8 +113,8 @@ core_ctx_create(struct instance *nci)
         return NULL;
     }
 
-    /* preconnect? servers in server pool */
-    status = server_pool_preconnect(ctx);
+    /* connect sentinel always, connect servers if preconnect is true */
+    status = server_pool_connect(ctx);
     if (status != NC_OK) {
         server_pool_disconnect(ctx);
         event_base_destroy(ctx->evb);

--- a/src/nc_mbuf.c
+++ b/src/nc_mbuf.c
@@ -283,3 +283,36 @@ mbuf_deinit(void)
     }
     ASSERT(nfree_mbufq == 0);
 }
+
+/* read a string from mbuf which is splited by char c,
+ * if c is found in mbuf, write the string before c to read_string,
+ * else return NC_ERROR.
+ */
+rstatus_t
+mbuf_read_string(struct mbuf *mbuf, char c, struct string *read_string)
+{
+    rstatus_t status;
+    uint32_t read_size;
+    uint8_t *p;
+
+    p = nc_strchr(mbuf->pos, mbuf->last, c);
+    if (p == NULL) {
+        log_error("mbuf read string failed, split char %c", c);
+        return NC_ERROR;
+    }
+
+    read_size = (uint32_t)(p - mbuf->pos);
+
+    if (read_string != NULL) {
+        string_deinit(read_string);
+        status = string_copy(read_string, mbuf->pos, read_size);
+        if (status != NC_OK) {
+            return status;
+        }
+    }
+
+    /* skip the split char c */
+    mbuf->pos += read_size + 1;
+
+    return NC_OK;
+}

--- a/src/nc_mbuf.h
+++ b/src/nc_mbuf.h
@@ -63,5 +63,6 @@ void mbuf_insert(struct mhdr *mhdr, struct mbuf *mbuf);
 void mbuf_remove(struct mhdr *mhdr, struct mbuf *mbuf);
 void mbuf_copy(struct mbuf *mbuf, uint8_t *pos, size_t n);
 struct mbuf *mbuf_split(struct mhdr *h, uint8_t *pos, mbuf_copy_t cb, void *cbarg);
+rstatus_t mbuf_read_string(struct mbuf *mbuf, char c, struct string *read_string);
 
 #endif

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -316,7 +316,7 @@ msg_get(struct conn *conn, bool request, bool redis)
     }
 
     log_debug(LOG_VVERB, "get msg %p id %"PRIu64" request %d owner sd %d",
-              msg, msg->id, msg->request, conn->sd);
+              msg, msg->id, msg->request, conn ? conn->sd : -1);
 
     return msg;
 }

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -452,6 +452,61 @@ msg_empty(struct msg *msg)
     return msg->mlen == 0 ? true : false;
 }
 
+/* read a line from msg's mbuf, then write to line_buf,
+ * if line_num is n, we will skip front n - 1 lines in the msg
+ */
+void
+msg_read_line(struct msg* msg, struct mbuf *line_buf, int line_num)
+{
+    struct mbuf *mbuf;
+    uint32_t mlen, buf_size, copy_size, search_size;
+    uint8_t *p;
+
+    mbuf_rewind(line_buf);
+
+    p = NULL;
+    for (mbuf = STAILQ_FIRST(&msg->mhdr);
+         mbuf != NULL && p == NULL; ) {
+
+        if (mbuf_empty(mbuf)) {
+            mbuf = STAILQ_NEXT(mbuf, next);
+            continue;
+        }
+
+        mlen = mbuf_length(mbuf);
+        buf_size = mbuf_size(line_buf);
+
+        search_size = mlen < buf_size ? mlen : buf_size;
+
+        p = nc_strchr(mbuf->pos, mbuf->pos + search_size, LF);
+        if(p == NULL) {
+            if (line_num == 1 && search_size >= buf_size) {
+                log_error("msg read line exceed buf size.");
+                return;
+            }
+            else {
+                copy_size = search_size;
+            }
+        }
+        else {
+            copy_size = (uint8_t *)p - mbuf->pos + 1;
+        }
+
+        /* line_num equals 1 means this line is wanted, so copy it.
+         * or else if the p is not null, let line_num minus 1,
+         * stand for skiped one line.
+         */
+        if (line_num == 1) {
+            nc_memcpy(line_buf->last, mbuf->pos, copy_size);
+            line_buf->last += copy_size;
+        } else if (p != NULL) {
+            line_num--;
+            p = NULL;
+        }
+        mbuf->pos += copy_size;
+    }
+}
+
 uint32_t
 msg_backend_idx(struct msg *msg, uint8_t *key, uint32_t keylen)
 {

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -489,7 +489,7 @@ msg_read_line(struct msg* msg, struct mbuf *line_buf, int line_num)
             }
         }
         else {
-            copy_size = (uint8_t *)p - mbuf->pos + 1;
+            copy_size = (uint32_t)(p - mbuf->pos + 1);
         }
 
         /* line_num equals 1 means this line is wanted, so copy it.

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -258,6 +258,7 @@ void msg_put(struct msg *msg);
 struct msg *msg_get_error(bool redis, err_t err);
 void msg_dump(struct msg *msg, int level);
 bool msg_empty(struct msg *msg);
+void msg_read_line(struct msg* msg, struct mbuf *line_buf, int line_num);
 rstatus_t msg_recv(struct context *ctx, struct conn *conn);
 rstatus_t msg_send(struct context *ctx, struct conn *conn);
 uint64_t msg_gen_frag_id(void);
@@ -280,6 +281,7 @@ void req_client_dequeue_omsgq(struct context *ctx, struct conn *conn, struct msg
 void req_server_dequeue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg);
 struct msg *req_recv_next(struct context *ctx, struct conn *conn, bool alloc);
 void req_recv_done(struct context *ctx, struct conn *conn, struct msg *msg, struct msg *nmsg);
+struct msg *req_fake(struct context *ctx, struct conn *conn);
 struct msg *req_send_next(struct context *ctx, struct conn *conn);
 void req_send_done(struct context *ctx, struct conn *conn, struct msg *msg);
 

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -46,6 +46,11 @@ req_log(struct msg *req)
         return;
     }
 
+    /* a fake request? */
+    if (req->owner == NULL) {
+        return;
+    }
+
     /* a fragment? */
     if (req->frag_id != 0 && req->frag_owner != req) {
         return;
@@ -84,11 +89,7 @@ req_log(struct msg *req)
      * Maybe we can store addrstr just like server_pool in conn struct
      * when connections are resolved
      */
-    if (req->owner == NULL) {
-        peer_str = "fake_client";
-    } else {
-        peer_str = nc_unresolve_peer_desc(req->owner->sd);
-    }
+    peer_str = nc_unresolve_peer_desc(req->owner->sd);
 
     req_type = msg_type_string(req->type);
 

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -470,6 +470,28 @@ req_make_reply(struct context *ctx, struct conn *conn, struct msg *req)
     return NC_OK;
 }
 
+struct msg *
+req_fake(struct context *ctx, struct conn *conn)
+{
+    struct msg *request;
+
+    /* the fake req don't have client conn */
+    request = msg_get(NULL, true, conn->redis);
+    if (request == NULL) {
+        log_error("get msg for fake req failed");
+        return NULL;
+    }
+
+    /* the fake req don't have client conn to reply.
+     * we know the response order, so we don't need the peer request.
+     * mark it noreply to release it when sent or socket error.
+     */
+    request->noreply = 1;
+
+    conn->enqueue_inq(ctx, conn, request);
+    return request;
+}
+
 static bool
 req_filter(struct context *ctx, struct conn *conn, struct msg *msg)
 {

--- a/src/nc_sentinel.c
+++ b/src/nc_sentinel.c
@@ -1,0 +1,479 @@
+#include <nc_core.h>
+#include <nc_conf.h>
+#include <nc_sentinel.h>
+
+static char *sentinel_reqs[] = {
+    INFO_SENTINEL,
+    SUB_SWITCH_REDIRECT
+};
+
+static sentinel_conn_status_t sentinel_status;
+
+struct conn *
+sentinel_conn(struct server *sentinel)
+{
+    struct conn *conn;
+
+    /* sentinel has only one connection */
+    if (sentinel->ns_conn_q == 0) {
+        return conn_get_sentinel(sentinel);
+    }
+    ASSERT(sentinel->ns_conn_q == 1);
+
+    conn = TAILQ_FIRST(&sentinel->s_conn_q);
+    ASSERT(!conn->client && !conn->proxy);
+
+    return conn;
+}
+
+rstatus_t
+sentinel_connect(struct context *ctx, struct server *sentinel)
+{
+    rstatus_t status;
+    struct conn *conn;
+    struct msg *request;
+    int cmd_num;
+    int i;
+
+    ASSERT(sentinel_status == SENTINEL_CONN_DISCONNECTED);
+
+    /* get the only connect of sentinel */
+    conn = sentinel_conn(sentinel);
+    if (conn == NULL) {
+        return NC_ENOMEM;
+    }
+
+    status = server_connect(ctx, sentinel, conn);
+    if(status != NC_OK) {
+        sentinel_close(ctx, conn);
+        return status;
+    }
+
+    /* set keepalive opt on sentinel socket to detect socket dead */
+    status = nc_set_keepalive(conn->sd, SENTINEL_KEEPALIVE);
+    if (status != NC_OK) {
+        log_error("set keepalive on s %d for sentienl server failed: %s",
+                  conn->sd, strerror(errno));
+        sentinel_close(ctx, conn);
+        return status;
+    }
+
+    cmd_num = sizeof(sentinel_reqs) / sizeof(char *);
+    for (i = 0; i < cmd_num; i++) {
+        request = req_fake(ctx, conn);
+        if(request == NULL) {
+            conn->err = errno;
+            sentinel_close(ctx, conn);
+            return NC_ENOMEM;
+        }
+
+        status = msg_append(request, (uint8_t *)(sentinel_reqs[i]), nc_strlen(sentinel_reqs[i]));
+        if (status != NC_OK) {
+            conn->err = errno;
+            sentinel_close(ctx, conn);
+            return status;
+        }
+
+        status = event_add_out(ctx->evb, conn);
+        if (status != NC_OK) {
+            conn->err = errno;
+            sentinel_close(ctx, conn);
+            return status;
+        }
+    }
+
+    sentinel_status = SENTINEL_CONN_SEND_REQ;
+
+    return NC_OK;
+}
+
+void
+sentinel_close(struct context *ctx, struct conn *conn)
+{
+    server_close(ctx, conn);
+    sentinel_status = SENTINEL_CONN_DISCONNECTED;
+}
+
+static rstatus_t
+sentinel_proc_sentinel_info(struct context *ctx, struct msg *msg)
+{
+    rstatus_t status;
+    int i, master_num, switch_num;
+    struct string pool_name, server_name, server_ip,
+                  tmp_string, sentinel_masters_prefix, master_ok;
+    struct mbuf *line_buf;
+    int server_port;
+
+    string_init(&tmp_string);
+    string_init(&pool_name);
+    string_init(&server_name);
+    string_init(&server_ip);
+    string_set_text(&sentinel_masters_prefix, "sentinel_masters");
+    string_set_text(&master_ok, "status=ok");
+
+    line_buf = mbuf_get();
+    if (line_buf == NULL) {
+        goto error;
+    }
+
+    /* get sentinel master num at line 3 */
+    msg_read_line(msg, line_buf, 3);
+    if (mbuf_length(line_buf) == 0) {
+        log_error("read line failed from sentinel ack info when skip line not used.");
+        goto error;
+    }
+    status = mbuf_read_string(line_buf, ':', &tmp_string);
+    if (status != NC_OK || string_compare(&sentinel_masters_prefix, &tmp_string)) {
+        goto error;
+    }
+    status = mbuf_read_string(line_buf, CR, &tmp_string);
+    if (status != NC_OK) {
+        goto error;
+    }
+    master_num = nc_atoi(tmp_string.data, tmp_string.len);
+    if (master_num < 0) {
+        log_error("parse master number from sentinel ack info failed.");
+        goto error;
+    }
+
+    /* skip 3 line in ack info which is not used. */
+    msg_read_line(msg, line_buf, 3);
+    if (mbuf_length(line_buf) == 0) {
+        log_error("read line failed from sentinel ack info when skip line not used.");
+        goto error;
+    }
+
+    /* parse master info from sentinel ack info */
+    switch_num = 0;
+    for (i = 0; i < master_num; i++) {
+        msg_read_line(msg, line_buf, 1);
+        if (mbuf_length(line_buf) == 0) {
+            log_error("read line failed from sentinel ack info when parse master item.");
+            goto error;
+        }
+        log_debug(LOG_INFO, "master item line : %.*s", mbuf_length(line_buf), line_buf->pos);
+
+        /* skip master item prefix */
+        status = mbuf_read_string(line_buf, ':', NULL);
+        if (status != NC_OK) {
+            log_error("skip master item prefix failed");
+            goto error;
+        }
+
+        /* skip master item server name prefix */
+        status = mbuf_read_string(line_buf, '=', NULL);
+        if (status != NC_OK) {
+            log_error("skip master item server name prefix failed.");
+            goto error;
+        }
+
+        /* get server pool name */
+        status = mbuf_read_string(line_buf, SENTINEL_SERVERNAME_SPLIT, &pool_name);
+        if (status != NC_OK) {
+            log_error("get server pool name failed.");
+            goto error;
+        }
+
+        /* get server name */
+        status = mbuf_read_string(line_buf, ',', &server_name);
+        if (status != NC_OK) {
+            log_error("get server name failed.");
+            goto error;
+        }
+
+        /* get master status */
+        status = mbuf_read_string(line_buf, ',', &tmp_string);
+        if (status != NC_OK) {
+            log_error("get master status failed.");
+            goto error;
+        }
+        if (string_compare(&master_ok, &tmp_string)) { 
+            log_error("master item status is not ok, use it anyway");
+        }
+
+        /* skip ip string prefix name */
+        status = mbuf_read_string(line_buf, '=', NULL);
+        if (status != NC_OK) {
+            log_error("skip master item address prefix failed.");
+            goto error;
+        }
+
+        /* get server ip string */
+        status = mbuf_read_string(line_buf, ':', &server_ip);
+        if (status != NC_OK) {
+            log_error("get server ip string failed.");
+            goto error;
+        }
+
+        /* get server port */
+        status = mbuf_read_string(line_buf, ',', &tmp_string);
+        if (status != NC_OK) {
+            log_error("get server port string failed.");
+            goto error;
+        }
+        server_port = nc_atoi(tmp_string.data, tmp_string.len);
+        if (server_port < 0) {
+            log_error("tanslate server port string to int failed.");
+            goto error;
+        }
+
+        status = server_switch(ctx, &pool_name, &server_name, &server_ip, server_port);
+        /* if server is switched, add switch number */
+        if (status == NC_OK) {
+            switch_num++;
+        }
+    }
+
+    if (switch_num > 0) {
+        conf_rewrite(ctx);
+    }
+
+    status = NC_OK;
+
+done:
+    if (line_buf != NULL) {
+        mbuf_put(line_buf);
+    }
+    string_deinit(&tmp_string);
+    string_deinit(&pool_name);
+    string_deinit(&server_name);
+    string_deinit(&server_ip);
+    return status;
+
+error:
+    status = NC_ERROR;
+    goto done;
+}
+
+static rstatus_t
+sentinel_proc_acksub(struct context *ctx, struct msg *msg, struct string *sub_channel)
+{
+    rstatus_t status;
+    struct string sub_titile, tmp_string;
+    struct mbuf *line_buf;
+
+    string_init(&tmp_string);
+    string_set_text(&sub_titile, "subscribe");
+
+    line_buf = mbuf_get();
+    if (line_buf == NULL) {
+        goto error;
+    }
+
+    /* get line in line num 3  for sub titile */
+    msg_read_line(msg, line_buf, 3);
+    if (mbuf_length(line_buf) == 0) {
+        log_error("read line failed from sentinel ack sub when skip line not used.");
+        goto error;
+    }
+    status = mbuf_read_string(line_buf, CR, &tmp_string);
+    if (status != NC_OK || string_compare(&sub_titile, &tmp_string)) {
+        goto error;
+    }
+
+    /* get line in line num 5  for sub channel */
+    msg_read_line(msg, line_buf, 2);
+    if (mbuf_length(line_buf) == 0) {
+        log_error("read line failed from sentinel ack sub when skip line not used.");
+        goto error;
+    }
+    status = mbuf_read_string(line_buf, CR, &tmp_string);
+    if (status != NC_OK || string_compare(sub_channel, &tmp_string)) {
+        goto error;
+    }
+
+    log_debug(LOG_INFO, "success sub channel %.*s from sentinel", sub_channel->len, sub_channel->data);
+
+    status = NC_OK;
+
+done:
+    if (line_buf != NULL) {
+        mbuf_put(line_buf);
+    }
+    string_deinit(&tmp_string);
+    return status;
+
+error:
+    status = NC_ERROR;
+    goto done;
+}
+
+static rstatus_t
+sentinel_proc_pub(struct context *ctx, struct msg *msg)
+{
+    rstatus_t status;
+    struct string pool_name, server_name, server_ip, tmp_string,
+                  pub_titile, pub_channel_switch, pub_channel_redirect;
+    struct mbuf *line_buf;
+    int server_port;
+
+    string_init(&tmp_string);
+    string_init(&pool_name);
+    string_init(&server_name);
+    string_init(&server_ip);
+
+    string_set_text(&pub_titile, "message");
+    string_set_text(&pub_channel_switch, SENTINEL_SWITCH_CHANNEL);
+    string_set_text(&pub_channel_redirect, SENTINEL_REDIRECT_CHANNEL);
+
+    line_buf = mbuf_get();
+    if (line_buf == NULL) {
+        goto error;
+    }
+
+    /* get line in line num 3  for pub titile */
+    msg_read_line(msg, line_buf, 3);
+    if (mbuf_length(line_buf) == 0) {
+        log_error("read line failed from sentinel pmessage when skip line not used.");
+        goto error;
+    }
+    status = mbuf_read_string(line_buf, CR, &tmp_string);
+    if (status != NC_OK || string_compare(&pub_titile, &tmp_string)) {
+        log_error("pub title error(line info %.*s)", tmp_string.len, tmp_string.data);
+        goto error;
+    }
+
+    /* get line in line num 5 for pub channel */
+    msg_read_line(msg, line_buf, 2);
+    if (mbuf_length(line_buf) == 0) {
+        log_error("read line failed from sentinel pmessage when skip line not used.");
+        goto error;
+    }
+    status = mbuf_read_string(line_buf, CR, &tmp_string);
+    if (status != NC_OK || (string_compare(&pub_channel_switch, &tmp_string) &&
+        string_compare(&pub_channel_redirect, &tmp_string))) {
+        log_error("pub channel error(line info %.*s)", tmp_string.len, tmp_string.data);
+        goto error;
+    }
+
+    /* get line in line num 7 for pub info */
+    msg_read_line(msg, line_buf, 2);
+    if (mbuf_length(line_buf) == 0) {
+        log_error("read line failed from sentinel pmessage when skip line not used.");
+        goto error;
+    }
+
+    /* parse switch master info */
+    /* get pool name */
+    status = mbuf_read_string(line_buf, SENTINEL_SERVERNAME_SPLIT, &pool_name);
+    if (status != NC_OK) {
+        log_error("get pool name string failed.");
+        goto error;
+    }
+
+    /* get server name */
+    status = mbuf_read_string(line_buf, ' ', &server_name);
+    if (status != NC_OK) {
+        log_error("get server name string failed.");
+        goto error;
+    }
+
+    /* skip old ip and port string */
+    status = mbuf_read_string(line_buf, ' ', NULL);
+    if (status != NC_OK) {
+        log_error("skip old ip string failed.");
+        goto error;
+    }
+    status = mbuf_read_string(line_buf, ' ', NULL);
+    if (status != NC_OK) {
+        log_error("skip old port string failed.");
+        goto error;
+    }
+
+    /* get new server ip string */
+    status = mbuf_read_string(line_buf, ' ', &server_ip);
+    if (status != NC_OK) {
+        log_error("get new server ip string failed.");
+        goto error;
+    }
+
+    /* get new server port */
+    status = mbuf_read_string(line_buf, CR, &tmp_string);
+    if (status != NC_OK) {
+        log_error("get new server port string failed.");
+        goto error;
+    }
+    server_port = nc_atoi(tmp_string.data, tmp_string.len);
+    if (server_port < 0) {
+        log_error("tanslate server port string to int failed.");
+        goto error;
+    }
+
+    status = server_switch(ctx, &pool_name, &server_name, &server_ip, server_port);
+    if (status == NC_OK) {
+        conf_rewrite(ctx);
+    }
+
+    status = NC_OK;
+
+done:
+    if (line_buf != NULL) {
+        mbuf_put(line_buf);
+    }
+    string_deinit(&tmp_string);
+    string_deinit(&server_ip);
+    string_deinit(&server_name);
+    string_deinit(&pool_name);
+    return status;
+
+error:
+    status = NC_ERROR;
+    goto done;
+}
+
+void
+sentinel_recv_done(struct context *ctx, struct conn *conn, struct msg *msg,
+              struct msg *nmsg)
+{
+    rstatus_t status;
+    struct string sub_channel;
+
+    ASSERT(!conn->client && !conn->proxy && conn->sentinel);
+    ASSERT(msg != NULL && conn->rmsg == msg);
+    ASSERT(!msg->request);
+    ASSERT(msg->owner == conn);
+    ASSERT(nmsg == NULL || !nmsg->request);
+    ASSERT(sentinel_status != SENTINEL_CONN_DISCONNECTED);
+
+    /* enqueue next message (response), if any */
+    conn->rmsg = nmsg;
+
+    switch (sentinel_status) {
+    case SENTINEL_CONN_SEND_REQ:
+        status = sentinel_proc_sentinel_info(ctx, msg);
+        if (status == NC_OK) {
+            sentinel_status = SENTINEL_CONN_ACK_INFO;
+        }
+        break;
+
+    case SENTINEL_CONN_ACK_INFO:
+        string_set_text(&sub_channel, SENTINEL_SWITCH_CHANNEL);
+        status = sentinel_proc_acksub(ctx, msg, &sub_channel);
+        if (status == NC_OK) {
+            sentinel_status = SENTINEL_CONN_ACK_SWITCH_SUB;
+        }
+        break;
+
+    case SENTINEL_CONN_ACK_SWITCH_SUB:
+        string_set_text(&sub_channel, SENTINEL_REDIRECT_CHANNEL);
+        status = sentinel_proc_acksub(ctx, msg, &sub_channel);
+        if (status == NC_OK) {
+            sentinel_status = SENTINEL_CONN_ACK_REDIRECT_SUB;
+        }
+        break;
+
+    case SENTINEL_CONN_ACK_REDIRECT_SUB:
+        status = sentinel_proc_pub(ctx, msg);
+        break;
+
+    default:
+        status = NC_ERROR;
+    }
+
+    rsp_put(msg);
+    
+    if (status != NC_OK) {
+        log_error("sentinel's response error, close sentinel conn.");
+        conn->done = 1;
+    }
+}

--- a/src/nc_sentinel.c
+++ b/src/nc_sentinel.c
@@ -34,6 +34,8 @@ sentinel_connect(struct context *ctx, struct server *sentinel)
     int cmd_num;
     int i;
 
+    ASSERT(sentinel->sentinel);
+
     /* get the only connect of sentinel */
     conn = sentinel_conn(sentinel);
     if (conn == NULL) {

--- a/src/nc_sentinel.c
+++ b/src/nc_sentinel.c
@@ -30,7 +30,7 @@ sentinel_connect(struct context *ctx, struct server *sentinel)
 {
     rstatus_t status;
     struct conn *conn;
-    struct msg *request;
+    struct msg *msg;
     int cmd_num;
     int i;
 
@@ -57,21 +57,14 @@ sentinel_connect(struct context *ctx, struct server *sentinel)
 
     cmd_num = sizeof(sentinel_reqs) / sizeof(char *);
     for (i = 0; i < cmd_num; i++) {
-        request = req_fake(ctx, conn);
-        if(request == NULL) {
+        msg = req_fake(ctx, conn);
+        if(msg == NULL) {
             conn->err = errno;
             sentinel_close(ctx, conn);
             return NC_ENOMEM;
         }
 
-        status = msg_append(request, (uint8_t *)(sentinel_reqs[i]), nc_strlen(sentinel_reqs[i]));
-        if (status != NC_OK) {
-            conn->err = errno;
-            sentinel_close(ctx, conn);
-            return status;
-        }
-
-        status = event_add_out(ctx->evb, conn);
+        status = msg_append(msg, (uint8_t *)(sentinel_reqs[i]), nc_strlen(sentinel_reqs[i]));
         if (status != NC_OK) {
             conn->err = errno;
             sentinel_close(ctx, conn);

--- a/src/nc_sentinel.h
+++ b/src/nc_sentinel.h
@@ -1,0 +1,33 @@
+#ifndef _NC_SENTINEL_H_
+#define _NC_SENTINEL_H_
+
+#include <nc_core.h>
+
+#define SENTINEL_ADDR             "127.0.0.1"
+#define SENTINEL_PORT             26379
+
+#define SENTINEL_KEEPALIVE        30
+
+#define SENTINEL_SERVERNAME_SPLIT '-'
+
+#define INFO_SENTINEL "info sentinel\r\n"
+#define SUB_SWITCH_REDIRECT "subscribe +switch-master +redirect-to-master\r\n"
+
+#define SENTINEL_SWITCH_CHANNEL   "+switch-master"
+#define SENTINEL_REDIRECT_CHANNEL "+redirect-to-master"
+
+typedef enum sentinel_conn_status {
+    SENTINEL_CONN_DISCONNECTED,
+    SENTINEL_CONN_SEND_REQ,
+    SENTINEL_CONN_ACK_INFO,
+    SENTINEL_CONN_ACK_SWITCH_SUB,
+    SENTINEL_CONN_ACK_REDIRECT_SUB,
+} sentinel_conn_status_t;
+
+struct conn * sentinel_conn(struct server *sentinel);
+rstatus_t sentinel_connect(struct context *ctx, struct server *sentinel);
+void sentinel_recv_done(struct context *ctx, struct conn *conn, struct msg *msg, struct msg *nmsg);
+void sentinel_close(struct context *ctx, struct conn *conn);
+int sentinel_reconnect(struct context *ctx, long long id, void *client_data);
+
+#endif

--- a/src/nc_sentinel.h
+++ b/src/nc_sentinel.h
@@ -3,26 +3,13 @@
 
 #include <nc_core.h>
 
-#define SENTINEL_ADDR             "127.0.0.1"
-#define SENTINEL_PORT             26379
-
 #define SENTINEL_KEEPALIVE        30
-
-#define SENTINEL_SERVERNAME_SPLIT '-'
 
 #define INFO_SENTINEL "info sentinel\r\n"
 #define SUB_SWITCH_REDIRECT "subscribe +switch-master +redirect-to-master\r\n"
 
 #define SENTINEL_SWITCH_CHANNEL   "+switch-master"
 #define SENTINEL_REDIRECT_CHANNEL "+redirect-to-master"
-
-typedef enum sentinel_conn_status {
-    SENTINEL_CONN_DISCONNECTED,
-    SENTINEL_CONN_SEND_REQ,
-    SENTINEL_CONN_ACK_INFO,
-    SENTINEL_CONN_ACK_SWITCH_SUB,
-    SENTINEL_CONN_ACK_REDIRECT_SUB,
-} sentinel_conn_status_t;
 
 struct conn * sentinel_conn(struct server *sentinel);
 rstatus_t sentinel_connect(struct context *ctx, struct server *sentinel);

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -718,12 +718,12 @@ server_pool_sentinel_check(struct context *ctx, struct server_pool *pool)
         return;
     }
 
-    if (pool->next_sentinel_reconn == 0LL) {
+    if (pool->next_sentinel_connect == 0LL) {
         return;
     }
 
     now = nc_usec_now();
-    if (now > 0 && now < pool->next_sentinel_reconn) {
+    if (now > 0 && now < pool->next_sentinel_connect) {
         return;
     }
 

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -905,7 +905,7 @@ server_pool_each_disconnect(void *elem, void *data)
     }
 
     if (array_n(&sp->sentinel)) {
-        status = array_each(&sp->server, server_each_disconnect, NULL);
+        status = array_each(&sp->sentinel, server_each_disconnect, NULL);
         if (status != NC_OK) {
             return status;
         }
@@ -1048,7 +1048,9 @@ server_pool_deinit(struct array *server_pool)
 
         server_deinit(&sp->server);
 
-        server_deinit(&sp->sentinel);
+        if (array_n(&sp->sentinel)) {
+            server_deinit(&sp->sentinel);
+        }
 
         log_debug(LOG_DEBUG, "deinit pool %"PRIu32" '%.*s'", sp->idx,
                   sp->name.len, sp->name.data);

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -709,7 +709,7 @@ server_switch(struct context *ctx, struct server *server,
     /* disconnect all the connection include the slaves's.
      * use the timer to disconnect after the file event loop.
      */
-    event_add_timer(ctx, (long long)0, server_disconnect, server, NULL);
+    //event_add_timer(ctx, (long long)0, server_disconnect, server, NULL);
 
     server_pool = server->owner;
     log_warn("success switch %.*s-%.*s to %.*s",

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -654,7 +654,7 @@ server_set_address(struct server *server, struct string *server_ip, int server_p
             server_ip->len, server_ip->data, server_port, server->weight);
 
     /* update conf_server's pname to used for conf update */
-    status = string_copy(&conf_server->pname, pname_buf, (uint32_t)(nc_strlen(pname_buf)));
+    status = string_copy(&conf_server->pname, (uint8_t *)pname_buf, (uint32_t)(nc_strlen(pname_buf)));
     if (status != NC_OK) {
         return status;
     }
@@ -679,14 +679,13 @@ server_switch(struct context *ctx, struct server *server,
 {
     rstatus_t status;
     struct server_pool *server_pool;
-    struct string pname, new_addr, slave_addr;
+    struct string pname;
     char pname_buf[NC_PNAME_MAXLEN];
-    uint32_t i;
 
     string_init(&pname);
     nc_snprintf(pname_buf, NC_PNAME_MAXLEN, "%.*s:%d:%d",
             server_ip->len, server_ip->data, server_port, server->weight);
-    status = string_copy(&pname, pname_buf, (uint32_t)(nc_strlen(pname_buf)));
+    status = string_copy(&pname, (uint8_t *)pname_buf, (uint32_t)(nc_strlen(pname_buf)));
     if (status != NC_OK) {
         return status;
     }

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -93,7 +93,8 @@ struct server_pool {
     uint32_t           nc_conn_q;            /* # client connection */
     struct conn_tqh    c_conn_q;             /* client connection q */
 
-    struct array       server;               /* server[] */
+    struct array       server;               /* servers: server[] */
+    struct array       sentinel;             /* sentinels: server[] */
     uint32_t           ncontinuum;           /* # continuum points */
     uint32_t           nserver_continuum;    /* # servers - live and dead on continuum (const) */
     struct continuum   *continuum;           /* continuum */

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -136,6 +136,8 @@ rstatus_t server_connect(struct context *ctx, struct server *server, struct conn
 void server_close(struct context *ctx, struct conn *conn);
 void server_connected(struct context *ctx, struct conn *conn);
 void server_ok(struct context *ctx, struct conn *conn);
+struct server* server_find_by_name(struct context *ctx, struct server_pool *server_pool, struct string *server_name);
+rstatus_t server_switch(struct context *ctx, struct server *server, struct string *server_ip, int server_port);
 
 uint32_t server_pool_idx(struct server_pool *pool, uint8_t *key, uint32_t keylen);
 struct conn *server_pool_conn(struct context *ctx, struct server_pool *pool, uint8_t *key, uint32_t keylen);

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -93,45 +93,45 @@ struct server {
 };
 
 struct server_pool {
-    uint32_t           idx;                  /* pool index */
-    struct context     *ctx;                 /* owner context */
+    uint32_t           idx;                   /* pool index */
+    struct context     *ctx;                  /* owner context */
 
-    struct conn        *p_conn;              /* proxy connection (listener) */
-    uint32_t           nc_conn_q;            /* # client connection */
-    struct conn_tqh    c_conn_q;             /* client connection q */
+    struct conn        *p_conn;               /* proxy connection (listener) */
+    uint32_t           nc_conn_q;             /* # client connection */
+    struct conn_tqh    c_conn_q;              /* client connection q */
 
-    struct array       server;               /* servers: server[] */
-    struct array       sentinel;             /* sentinels: server[] */
-    uint32_t           ncontinuum;           /* # continuum points */
-    uint32_t           nserver_continuum;    /* # servers - live and dead on continuum (const) */
-    struct continuum   *continuum;           /* continuum */
-    uint32_t           nlive_server;         /* # live server */
-    int64_t            next_rebuild;         /* next distribution rebuild time in usec */
-    int64_t            next_sentinel_reconn; /* next reconnect sentinel time in usec */
-    uint32_t           sentinel_idx;         /* the connected sentinel's idx */
+    struct array       server;                /* servers: server[] */
+    struct array       sentinel;              /* sentinels: server[] */
+    uint32_t           ncontinuum;            /* # continuum points */
+    uint32_t           nserver_continuum;     /* # servers - live and dead on continuum (const) */
+    struct continuum   *continuum;            /* continuum */
+    uint32_t           nlive_server;          /* # live server */
+    int64_t            next_rebuild;          /* next distribution rebuild time in usec */
+    int64_t            next_sentinel_connect; /* next reconnect sentinel time in usec */
+    uint32_t           sentinel_idx;          /* the connected sentinel's idx */
 
-    struct string      name;                 /* pool name (ref in conf_pool) */
-    struct string      addrstr;              /* pool address (ref in conf_pool) */
-    struct string      redis_auth;           /* redis_auth password */
-    uint16_t           port;                 /* port */
-    int                family;               /* socket family */
-    socklen_t          addrlen;              /* socket length */
-    struct sockaddr    *addr;                /* socket address (ref in conf_pool) */
-    mode_t             perm;                 /* socket permission */
-    int                dist_type;            /* distribution type (dist_type_t) */
-    int                key_hash_type;        /* key hash type (hash_type_t) */
-    hash_t             key_hash;             /* key hasher */
-    struct string      hash_tag;             /* key hash tag (ref in conf_pool) */
-    int                timeout;              /* timeout in msec */
-    int                backlog;              /* listen backlog */
-    int                redis_db;             /* redis database to connect to */
-    uint32_t           client_connections;   /* maximum # client connection */
-    uint32_t           server_connections;   /* maximum # server connection */
-    int64_t            server_retry_timeout; /* server retry timeout in usec */
-    uint32_t           server_failure_limit; /* server failure limit */
-    unsigned           auto_eject_hosts:1;   /* auto_eject_hosts? */
-    unsigned           preconnect:1;         /* preconnect? */
-    unsigned           redis:1;              /* redis? */
+    struct string      name;                  /* pool name (ref in conf_pool) */
+    struct string      addrstr;               /* pool address (ref in conf_pool) */
+    struct string      redis_auth;            /* redis_auth password */
+    uint16_t           port;                  /* port */
+    int                family;                /* socket family */
+    socklen_t          addrlen;               /* socket length */
+    struct sockaddr    *addr;                 /* socket address (ref in conf_pool) */
+    mode_t             perm;                  /* socket permission */
+    int                dist_type;             /* distribution type (dist_type_t) */
+    int                key_hash_type;         /* key hash type (hash_type_t) */
+    hash_t             key_hash;              /* key hasher */
+    struct string      hash_tag;              /* key hash tag (ref in conf_pool) */
+    int                timeout;               /* timeout in msec */
+    int                backlog;               /* listen backlog */
+    int                redis_db;              /* redis database to connect to */
+    uint32_t           client_connections;    /* maximum # client connection */
+    uint32_t           server_connections;    /* maximum # server connection */
+    int64_t            server_retry_timeout;  /* server retry timeout in usec */
+    uint32_t           server_failure_limit;  /* server failure limit */
+    unsigned           auto_eject_hosts:1;    /* auto_eject_hosts? */
+    unsigned           preconnect:1;          /* preconnect? */
+    unsigned           redis:1;               /* redis? */
 };
 
 void server_ref(struct conn *conn, void *owner);

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -73,7 +73,7 @@ struct server {
     struct server_pool *owner;        /* owner pool */
 
     /* use this pointer to modify conf_server when switch server happens */
-    struct conf_server *conf_server;   /* conf_server transformed from */
+    struct conf_server *conf_server;  /* conf_server transformed from */
 
     struct string      pname;         /* name:port:weight (ref in conf_server) */
     struct string      name;          /* name (ref in conf_server) */

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -59,6 +59,8 @@
  *            //
  */
 
+#define NC_PNAME_MAXLEN                 32
+
 typedef uint32_t (*hash_t)(const char *, size_t);
 
 struct continuum {
@@ -69,6 +71,9 @@ struct continuum {
 struct server {
     uint32_t           idx;           /* server index */
     struct server_pool *owner;        /* owner pool */
+
+    /* use this pointer to modify conf_server when switch server happens */
+    struct conf_server *conf_server;   /* conf_server transformed from */
 
     struct string      pname;         /* name:port:weight (ref in conf_server) */
     struct string      name;          /* name (ref in conf_server) */

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -88,6 +88,8 @@ struct server {
 
     int64_t            next_retry;    /* next retry time in usec */
     uint32_t           failure_count; /* # consecutive failures */
+
+    unsigned           sentinel:1;    /* redis sentinel? */
 };
 
 struct server_pool {
@@ -134,7 +136,7 @@ void server_ref(struct conn *conn, void *owner);
 void server_unref(struct conn *conn);
 int server_timeout(struct conn *conn);
 bool server_active(struct conn *conn);
-rstatus_t server_init(struct array *server, struct array *conf_server, struct server_pool *sp);
+rstatus_t server_init(struct array *server, struct array *conf_server, struct server_pool *sp, bool sentinel);
 void server_deinit(struct array *server);
 struct conn *server_conn(struct server *server);
 rstatus_t server_connect(struct context *ctx, struct server *server, struct conn *conn);

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -147,7 +147,7 @@ rstatus_t server_switch(struct context *ctx, struct server *server, struct strin
 uint32_t server_pool_idx(struct server_pool *pool, uint8_t *key, uint32_t keylen);
 struct conn *server_pool_conn(struct context *ctx, struct server_pool *pool, uint8_t *key, uint32_t keylen);
 rstatus_t server_pool_run(struct server_pool *pool);
-rstatus_t server_pool_preconnect(struct context *ctx);
+rstatus_t server_pool_connect(struct context *ctx);
 void server_pool_disconnect(struct context *ctx);
 rstatus_t server_pool_init(struct array *server_pool, struct array *conf_pool, struct context *ctx);
 void server_pool_deinit(struct array *server_pool);

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -107,6 +107,8 @@ struct server_pool {
     struct continuum   *continuum;           /* continuum */
     uint32_t           nlive_server;         /* # live server */
     int64_t            next_rebuild;         /* next distribution rebuild time in usec */
+    int64_t            next_sentinel_reconn; /* next reconnect sentinel time in usec */
+    uint32_t           sentinel_idx;         /* the connected sentinel's idx */
 
     struct string      name;                 /* pool name (ref in conf_pool) */
     struct string      addrstr;              /* pool address (ref in conf_pool) */

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -1142,6 +1142,11 @@ _stats_server_incr(struct context *ctx, struct server *server,
 {
     struct stats_metric *stm;
 
+    /* proxy don't stats sentinel server */
+    if (server->sentinel) {
+        return;
+    }
+
     stm = stats_server_to_metric(ctx, server, fidx);
 
     ASSERT(stm->type == STATS_COUNTER || stm->type == STATS_GAUGE);
@@ -1156,6 +1161,11 @@ _stats_server_decr(struct context *ctx, struct server *server,
                    stats_server_field_t fidx)
 {
     struct stats_metric *stm;
+
+    /* proxy don't stats sentinel server */
+    if (server->sentinel) {
+        return;
+    }
 
     stm = stats_server_to_metric(ctx, server, fidx);
 
@@ -1172,6 +1182,11 @@ _stats_server_incr_by(struct context *ctx, struct server *server,
 {
     struct stats_metric *stm;
 
+    /* proxy don't stats sentinel server */
+    if (server->sentinel) {
+        return;
+    }
+
     stm = stats_server_to_metric(ctx, server, fidx);
 
     ASSERT(stm->type == STATS_COUNTER || stm->type == STATS_GAUGE);
@@ -1187,6 +1202,11 @@ _stats_server_decr_by(struct context *ctx, struct server *server,
 {
     struct stats_metric *stm;
 
+    /* proxy don't stats sentinel server */
+    if (server->sentinel) {
+        return;
+    }
+
     stm = stats_server_to_metric(ctx, server, fidx);
 
     ASSERT(stm->type == STATS_GAUGE);
@@ -1201,6 +1221,11 @@ _stats_server_set_ts(struct context *ctx, struct server *server,
                      stats_server_field_t fidx, int64_t val)
 {
     struct stats_metric *stm;
+
+    /* proxy don't stats sentinel server */
+    if (server->sentinel) {
+        return;
+    }
 
     stm = stats_server_to_metric(ctx, server, fidx);
 

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -516,7 +516,7 @@ stats_add_header(struct stats *st)
         return status;
     }
 
-    status = stats_add_num(st, &st->ntotal_conn_str, conn_ntotal_conn());
+    status = stats_add_num(st, &st->ntotal_conn_str, (int64_t)conn_ntotal_conn());
     if (status != NC_OK) {
         return status;
     }

--- a/src/nc_util.c
+++ b/src/nc_util.c
@@ -132,15 +132,16 @@ nc_set_rcvbuf(int sd, int size)
 int
 nc_set_keepalive(int sd, int interval)
 {
-    int keepalive, keepidle, keepintvl, keepcnt;
+    int keepalive, keepidle, keepintvl, keepcnt, status;
     socklen_t len;
 
 
     keepalive = 1;
     len = sizeof(keepalive);
-    if (setsockopt(sd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, len) == -1)
+    status = setsockopt(sd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, len);
+    if (status == -1)
     {
-        return NC_ERROR;
+        return status;
     }
 
 #ifdef __linux__
@@ -151,8 +152,9 @@ nc_set_keepalive(int sd, int interval)
     /* Send first probe after interval. */
     keepidle = interval;
     len = sizeof(keepidle);
-    if (setsockopt(sd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, len) < 0) {
-        return NC_ERROR;
+    status = setsockopt(sd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, len);
+    if (status < 0) {
+        return status;
     }
 
     /* Send next probes after the specified interval. Note that we set the
@@ -161,20 +163,22 @@ nc_set_keepalive(int sd, int interval)
     keepintvl = interval/3;
     len = sizeof(keepintvl);
     if (keepintvl == 0) keepintvl = 1;
-    if (setsockopt(sd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, len) < 0) {
-        return NC_ERROR;
+    status = setsockopt(sd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, len);
+    if (status < 0) {
+        return status;
     }
 
     /* Consider the socket in error state after three we send three ACK
      * probes without getting a reply. */
     keepcnt = 3;
     len = sizeof(keepcnt);
-    if (setsockopt(sd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, len) < 0) {
-        return NC_ERROR;
+    status = setsockopt(sd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, len);
+    if (status < 0) {
+        return status;
     }
 #endif
 
-    return NC_OK;
+    return 0;
 }
 
 int

--- a/src/nc_util.h
+++ b/src/nc_util.h
@@ -85,6 +85,7 @@ int nc_set_tcpnodelay(int sd);
 int nc_set_linger(int sd, int timeout);
 int nc_set_sndbuf(int sd, int size);
 int nc_set_rcvbuf(int sd, int size);
+int nc_set_keepalive(int sd, int interval);
 int nc_get_soerror(int sd);
 int nc_get_sndbuf(int sd);
 int nc_get_rcvbuf(int sd);


### PR DESCRIPTION
Hi, @manjuraj @idning , I made a patch for twemproxy to let it work with redis-sentinel.
This patch is implemented as the design mentioned in issue 297.
In addition, I add keepalive to the sentinel pub/sub connection. Because sentinel pub/sub connection don't have heartbeat, we must add keepalive to check if the connection is dead. The implemention of nc_set_keepalive is copied from redis.
You can configure a server_pool like sigma in conf/nutcracker.yml to use this feature.
I hope to hear your feedback about this patch.