### PR TITLE
Add switch to use TCPKEEPALIVE option

### DIFF
--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -74,6 +74,10 @@ static struct command conf_commands[] = {
       conf_set_bool,
       offsetof(struct conf_pool, redis) },
 
+    { string("tcpkeepalive"),
+      conf_set_bool,
+      offsetof(struct conf_pool, tcpkeepalive) },
+
     { string("redis_auth"),
       conf_set_string,
       offsetof(struct conf_pool, redis_auth) },
@@ -193,6 +197,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
     cp->client_connections = CONF_UNSET_NUM;
 
     cp->redis = CONF_UNSET_NUM;
+    cp->tcpkeepalive = CONF_UNSET_NUM;
     cp->redis_db = CONF_UNSET_NUM;
     cp->preconnect = CONF_UNSET_NUM;
     cp->auto_eject_hosts = CONF_UNSET_NUM;
@@ -283,6 +288,8 @@ conf_pool_each_transform(void *elem, void *data)
     sp->hash_tag = cp->hash_tag;
 
     sp->redis = cp->redis ? 1 : 0;
+    sp->tcpkeepalive = cp->tcpkeepalive ? 1 : 0;
+
     sp->redis_auth = cp->redis_auth;
     sp->redis_db = cp->redis_db;
     sp->timeout = cp->timeout;
@@ -1226,6 +1233,10 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
 
     if (cp->redis == CONF_UNSET_NUM) {
         cp->redis = CONF_DEFAULT_REDIS;
+    }
+
+    if (cp->tcpkeepalive == CONF_UNSET_NUM) {
+        cp->tcpkeepalive = CONF_DEFAULT_TCPKEEPALIVE;
     }
 
     if (cp->redis_db == CONF_UNSET_NUM) {

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -54,6 +54,7 @@
 #define CONF_DEFAULT_SERVER_FAILURE_LIMIT    2
 #define CONF_DEFAULT_SERVER_CONNECTIONS      1
 #define CONF_DEFAULT_KETAMA_PORT             11211
+#define CONF_DEFAULT_TCPKEEPALIVE            false
 
 struct conf_listen {
     struct string   pname;   /* listen: as "name:port" */
@@ -83,6 +84,7 @@ struct conf_pool {
     int                backlog;               /* backlog: */
     int                client_connections;    /* client_connections: */
     int                redis;                 /* redis: */
+    int                tcpkeepalive;          /* tcpkeepalive: */
     struct string      redis_auth;            /* redis auth password */
     int                redis_db;              /* redis_db: */
     int                preconnect;            /* preconnect: */

--- a/src/nc_proxy.c
+++ b/src/nc_proxy.c
@@ -274,6 +274,7 @@ proxy_accept(struct context *ctx, struct conn *p)
     rstatus_t status;
     struct conn *c;
     int sd;
+    struct server_pool *pool = p->owner;
 
     ASSERT(p->proxy && !p->client);
     ASSERT(p->sd > 0);
@@ -355,6 +356,14 @@ proxy_accept(struct context *ctx, struct conn *p)
                   strerror(errno));
         c->close(ctx, c);
         return status;
+    }
+
+    if (pool->tcpkeepalive) {
+        status = nc_set_tcpkeepalive(c->sd);
+        if (status < 0) {
+            log_warn("set tcpkeepalive on c %d from p %d failed, ignored: %s",
+                     c->sd, p->sd, strerror(errno));
+        }
     }
 
     if (p->family == AF_INET || p->family == AF_INET6) {

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -122,6 +122,7 @@ struct server_pool {
     unsigned           auto_eject_hosts:1;   /* auto_eject_hosts? */
     unsigned           preconnect:1;         /* preconnect? */
     unsigned           redis:1;              /* redis? */
+    unsigned           tcpkeepalive:1;       /* tcpkeepalive? */
 };
 
 void server_ref(struct conn *conn, void *owner);

--- a/src/nc_util.c
+++ b/src/nc_util.c
@@ -110,6 +110,14 @@ nc_set_linger(int sd, int timeout)
 }
 
 int
+nc_set_tcpkeepalive(int sd)
+{
+    int val = 1;
+    return setsockopt(sd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
+}
+
+
+int
 nc_set_sndbuf(int sd, int size)
 {
     socklen_t len;

--- a/src/nc_util.h
+++ b/src/nc_util.h
@@ -85,6 +85,7 @@ int nc_set_tcpnodelay(int sd);
 int nc_set_linger(int sd, int timeout);
 int nc_set_sndbuf(int sd, int size);
 int nc_set_rcvbuf(int sd, int size);
+int nc_set_tcpkeepalive(int sd);
 int nc_get_soerror(int sd);
 int nc_get_sndbuf(int sd);
 int nc_get_rcvbuf(int sd);


### PR DESCRIPTION
I add tcpkeepalive option in pool.
to remove dead peer, I think it is better to add TCP KEEPALIVE
 
to use default value and system setting. I don't set other value.