### PR TITLE
Added beholder to the Utils section, a python agent that works together ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ https://launchpad.net/~twemproxy/+archive/ubuntu/daily
 + [sensu-metrics](https://github.com/sensu/sensu-community-plugins/blob/master/plugins/twemproxy/twemproxy-metrics.rb)
 + [redis-mgr](https://github.com/idning/redis-mgr)
 + [smitty for twemproxy failover](https://github.com/areina/smitty)
++ [Beholder, a Python agent for twemproxy failover](https://github.com/Serekh/beholder)
 + [chef cookbook](https://supermarket.getchef.com/cookbooks/twemproxy)
 + [twemsentinel] (https://github.com/yak0/twemsentinel)
 


### PR DESCRIPTION
...redis sentinel used to extend the HA capabilities of twemproxy even after a redis node has failed.