### PR TITLE
Source init defaults before setting daemon args.

### DIFF
--- a/scripts/nutcracker.init.debian
+++ b/scripts/nutcracker.init.debian
@@ -17,16 +17,16 @@ LOGFILE=/opt/nutcracker/log/nutcracker.log
 DAEMON=/opt/nutcracker/sbin/nutcracker
 PIDFILE=/var/run/nutcracker/$NAME.pid
 STATSPORT=22222
-DAEMON_ARGS="-c $CONFFILE -o $LOGFILE -p $PIDFILE -s $STATSPORT -v 11 -m 2048 -d"
-#DAEMON_ARGS="-c $CONFFILE -p $PIDFILE -s $STATSPORT -d"
 SCRIPTNAME=/etc/init.d/$NAME
 
 ulimit -Hn 100000
 ulimit -Sn 100000
 
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
 [ -x $DAEMON ] || exit 0
 
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+DAEMON_ARGS="-c $CONFFILE -o $LOGFILE -p $PIDFILE -s $STATSPORT -v 11 -m 2048 -d"
 
 . /lib/init/vars.sh
 


### PR DESCRIPTION
DAEMON_ARGS needs to be set after defaults are loaded
to facilitate overrides. The following order is now in
place:

1. load defaults
2. check if daemon is executable
3. set DAEMON_ARGS

This change is useful when package `nutcracker` with a tool like [fpm](https://github.com/jordansissel/fpm).