### PR TITLE
Support "touch" command for memcached and allow negative exptime

### DIFF
--- a/notes/memcache.txt
+++ b/notes/memcache.txt
@@ -37,6 +37,10 @@
   where,
   <value> - uint64_t
 
+- Touch Command (touch):
+
+  touch <key> <expiry>[noreply]\r\n
+
 - Misc Commands (quit)
 
   quit\r\n
@@ -73,7 +77,7 @@
   EXISTS indicates that the item you are trying to store with a cas has been modified since you last fetched it.
   NOT_FOUND indicates that the item you are trying to store with a cas does not exist.
 
-- Delete Command Response:
+- Delete Command Responses:
 
   NOT_FOUND\r\n
   DELETED\r\n
@@ -92,10 +96,15 @@
   where,
   <value> - uint64_t : new key value after incr or decr operation
 
+- Touch Command Responses:
+
+  NOT_FOUND\r\n
+  TOUCHED\r\n
+
 - Statistics Response
   [STAT <name> <value>\r\n]+END\r\n
 
-- Misc Response
+- Misc Responses
 
   OK\r\n
   VERSION <version>\r\n

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -46,6 +46,7 @@ typedef enum msg_parse_result {
     ACTION( REQ_MC_PREPEND )                                                                        \
     ACTION( REQ_MC_INCR )                      /* memcache arithmetic request */                    \
     ACTION( REQ_MC_DECR )                                                                           \
+    ACTION( REQ_MC_TOUCH )                     /* memcache touch request */                         \
     ACTION( REQ_MC_QUIT )                      /* memcache quit request */                          \
     ACTION( RSP_MC_NUM )                       /* memcache arithmetic response */                   \
     ACTION( RSP_MC_STORED )                    /* memcache cas and storage response */              \
@@ -55,6 +56,7 @@ typedef enum msg_parse_result {
     ACTION( RSP_MC_END )                                                                            \
     ACTION( RSP_MC_VALUE )                                                                          \
     ACTION( RSP_MC_DELETED )                   /* memcache delete response */                       \
+    ACTION( RSP_MC_TOUCHED )                   /* memcache touch response */                        \
     ACTION( RSP_MC_ERROR )                     /* memcache error responses */                       \
     ACTION( RSP_MC_CLIENT_ERROR )                                                                   \
     ACTION( RSP_MC_SERVER_ERROR )                                                                   \

--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -554,7 +554,7 @@ memcache_parse_req(struct msg *r)
 
         case SW_SPACES_BEFORE_NUM:
             if (ch != ' ') {
-                if (!isdigit(ch)) {
+                if (!(isdigit(ch) || ch == '-')) {
                     goto error;
                 }
                 /* num_start <- p; num <- ch - '0'  */


### PR DESCRIPTION
The PR is similar to https://github.com/Netflix/dynomite/pull/76

* * *

The [touch command](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L318) is not supported in twemproxy. I'm not sure if there's any deliberate purpose, if so, please tell me.

Touch with negative exptime is supported by memcached while not well documented. I'm not familiar with its inner implements but I guess the proxy should better transport without any interruption.

```
 telnet localhost 11211
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
set foo 0 0 2
10
STORED
get foo
VALUE foo 0 2
10
END
touch foo -1
TOUCHED
get foo
END
```
