### PR TITLE
fix crash when mset has invalid pair

### DIFF
--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1190,9 +1190,6 @@ redis_parse_req(struct msg *r)
                     }
                     state = SW_KEY_LEN;
                 } else if (redis_argkvx(r)) {
-                    if (r->rnarg == 0) {
-                        goto done;
-                    }
                     if (r->narg % 2 == 0) {
                         goto error;
                     }


### PR DESCRIPTION
fix crash when mset has invalid pair

```c
127.0.0.1:22121> mset key1
Could not connect to Redis at 127.0.0.1:22121: Connection refused
```

and this time twemproxy crashed.