### PR TITLE
fix bug hang when command just has type only

### DIFF
--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -406,6 +406,7 @@ redis_parse_req(struct msg *r)
                 if (r->rnarg == 0) {
                     goto error;
                 }
+
                 r->narg = r->rnarg;
                 r->narg_end = p;
                 r->token = NULL;
@@ -1068,6 +1069,8 @@ redis_parse_req(struct msg *r)
             case LF:
                 if (redis_argz(r)) {
                     goto done;
+                } else if (r->narg == 1) {
+                    goto error;
                 } else if (redis_argeval(r)) {
                     state = SW_ARG1_LEN;
                 } else {


### PR DESCRIPTION
In twemproxy.
command that just has type only(except ping/quit) cause hanging

ex)
```c
mset
```

so this patch return parse error with this command(not hang)