### PR TITLE
fix bug crash when get command without key and whitespace

### DIFF
--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -343,12 +343,14 @@ memcache_parse_req(struct msg *r)
             }
             if (ch == ' ' || ch == CR) {
                 struct keypos *kpos;
-
-                if ((p - r->token) > MEMCACHE_MAX_KEY_LENGTH) {
+                int keylen = p - r->token;
+                if (keylen > MEMCACHE_MAX_KEY_LENGTH) {
                     log_error("parsed bad req %"PRIu64" of type %d with key "
                               "prefix '%.*s...' and length %d that exceeds "
                               "maximum key length", r->id, r->type, 16,
                               r->token, p - r->token);
+                    goto error;
+                } else if (keylen == 0) {
                     goto error;
                 }
 


### PR DESCRIPTION
In twemproxy.
"get" command cause crash.

ex) after get there is space. '_' means space.
```c
get_  
```

so this patch return parse error when key len is 0 with get command