### PR TITLE
Remove redundant conditional judgement in rbtree deletion

### DIFF
--- a/src/nc_rbtree.c
+++ b/src/nc_rbtree.c
@@ -218,11 +218,7 @@ rbtree_delete(struct rbtree *tree, struct rbnode *node)
         subst = node;
     } else {
         subst = rbtree_node_min(node->right, sentinel);
-        if (subst->left != sentinel) {
-            temp = subst->left;
-        } else {
-            temp = subst->right;
-        }
+        temp = subst->right;
     }
 
     if (subst == *root) {


### PR DESCRIPTION
In binary tree deletion, as is defined, first we need to find the
minimum node of its right sub-tree to replace the location of the node
to be deleted when it has both its left and right children. Then we
shall trace its sub-tree to find the minimum node in `ngx_rbtree_min`
function. Since the terminal condition of the tracing loop has already
been set as `node->left == sentinel`, there is no need to leave the
following if-condition judging whether the substitute node's left child
is the sentinel any more because the program will never run here. And
the code will be cleaner as well as may run faster in some situations
after removing this redundant conditional branch.

In C++ SGI STL stl_tree.c source, we can see there is no if-else-
condition judgement in rbtree deletion:

https://github.com/dutor/stl/blob/master/sgi/stl_tree.h#L317

By the way, the current released Nginx source still has this issue but
I have no idea how to commit this patch to the upstream.

Signed-off-by: Leo Ma <begeekmyfriend@gmail.com>