### PR TITLE
fix crc16

### DIFF
--- a/src/hashkit/nc_crc16.c
+++ b/src/hashkit/nc_crc16.c
@@ -56,7 +56,7 @@ uint32_t
 hash_crc16(const char *key, size_t key_length)
 {
     uint64_t x;
-    uint32_t crc = 0;
+    uint16_t crc = 0;
 
     for (x=0; x < key_length; x++) {
         crc = (crc << 8) ^ crc16tab[((crc >> 8) ^ *key++) & 0x00ff];


### PR DESCRIPTION
nc_crc16 impl is not correct, eg, "FM|ivector_2129920" -> 2859837793, the result should be 43361.

crc16's return value should never beyond 65536, @manjuraj @idning, pls review.

refer to https://github.com/twitter/twemproxy/pull/313, and i dont know how do you think about this kind of error.
