### PR TITLE
Document the redis_db config setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Twemproxy can be configured through a YAML file specified by the -c or --conf-fi
 + **preconnect**: A boolean value that controls if twemproxy should preconnect to all the servers in this pool on process start. Defaults to false.
 + **redis**: A boolean value that controls if a server pool speaks redis or memcached protocol. Defaults to false.
 + **redis_auth**: Authenticate to the Redis server on connect.
++ **redis_db**: The DB number to use on the pool servers. Defaults to 0. Note: Twemproxy will always present itself to clients as DB 0.
 + **server_connections**: The maximum number of connections that can be opened to each server. By default, we open at most 1 server connection.
 + **auto_eject_hosts**: A boolean value that controls if server should be ejected temporarily when it fails consecutively server_failure_limit times. See [liveness recommendations](notes/recommendation.md#liveness) for information. Defaults to false.
 + **server_retry_timeout**: The timeout value in msec to wait for before retrying on a temporarily ejected server, when auto_eject_host is set to true. Defaults to 30000 msec.


### PR DESCRIPTION
I noticed when browsing the code that Twemproxy does support using a DB other than 0 on the pool servers, which would have helped me out at one point. Documenting it so that others might benefit.