### PR TITLE
issue: #362 fix bug hang when command just has type only

### DIFF
--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1099,6 +1099,8 @@ redis_parse_req(struct msg *r)
             case LF:
                 if (redis_argz(r)) {
                     goto done;
+                } else if (r->narg == 1) {
+                    goto error;
                 } else if (redis_argeval(r)) {
                     state = SW_ARG1_LEN;
                 } else {

--- a/tests/test_redis/test_protocol.py
+++ b/tests/test_redis/test_protocol.py
@@ -87,13 +87,4 @@ def test_wrong_argc():
     s = get_conn()
 
     s.sendall('*1\r\n$3\r\nGET\r\n')
-    assert_fail('timed out', s.recv, 10000)
-
-    ## assert('' == s.recv(1000))  # peer is closed
-    #assert(data.startswith('-ERR wrong number of arguments'))
-
-    #s.sendall('*3\r\n$3\r\nSET\r\n$5\r\nkkkkk\r\n$5\r\nvvvvv\r\n')
-    ## s.sendall('*2\r\n$3\r\nGET\r\n$5\r\nkkkkk\r\n')
-    #data = s.recv(10000)
-    #assert(data == '+OK\r\n')
-
+    assert('' == s.recv(1000))  # peer is closed


### PR DESCRIPTION
https://github.com/twitter/twemproxy/pull/362#issuecomment-113024260

@manjuraj  some of my mistakes, my github commit log is mixed. so I made new pr :)

In twemproxy.
command that just has type only(except ping/quit) cause hanging

ex)
```c
mset
```

so this patch return parse error with this command(not hang)