### PR TITLE
Add REUSEPORT to proxy socket. 

### DIFF
--- a/src/nc_proxy.c
+++ b/src/nc_proxy.c
@@ -98,6 +98,7 @@ proxy_reuse(struct conn *p)
     switch (p->family) {
     case AF_INET:
     case AF_INET6:
+        nc_set_reuseport(p->sd);
         status = nc_set_reuseaddr(p->sd);
         break;
 

--- a/src/nc_util.c
+++ b/src/nc_util.c
@@ -64,6 +64,18 @@ nc_set_nonblocking(int sd)
 }
 
 int
+nc_set_reuseport(int sd)
+{
+    int reuse;
+    socklen_t len;
+
+    reuse = 1;
+    len = sizeof(reuse);
+
+    return setsockopt(sd, SOL_SOCKET, SO_REUSEPORT, &reuse, len);
+}
+
+int
 nc_set_reuseaddr(int sd)
 {
     int reuse;

--- a/src/nc_util.h
+++ b/src/nc_util.h
@@ -81,6 +81,7 @@
 int nc_set_blocking(int sd);
 int nc_set_nonblocking(int sd);
 int nc_set_reuseaddr(int sd);
+int nc_set_reuseport(int sd);
 int nc_set_tcpnodelay(int sd);
 int nc_set_linger(int sd, int timeout);
 int nc_set_sndbuf(int sd, int size);


### PR DESCRIPTION
1. Allow twemproxy to work in multi-process, solving performance issue of using only 1 core.
2. Allow graceful reload in some way. (Start new process with new
   configuration, then kill the old one after some time. If twemproxy
   can stop listening on proxy sockets on specific signal, it'll work better.
   This mechanism is very similar to haproxy's)