### PR TITLE
Added Hootsuite as twemproxy users

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ https://launchpad.net/~twemproxy/+archive/ubuntu/daily
 + [Poshmark](https://poshmark.com/)
 + [FanDuel](https://www.fanduel.com/)
 + [Bloomreach](http://bloomreach.com/)
++ [Hootsuite](https://hootsuite.com)
 
 ## Issues and Support
 


### PR DESCRIPTION
Hootsuite uses twemproxy in front of both Memcached and Redis services. Our blog post on our migration from MySQL and Memcached to Redis that uses Twemproxy is shown here: http://code.hootsuite.com/mysql-to-redis/