### PR TITLE
support geo commands and nested multibulk reply.

### DIFF
--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -255,6 +255,7 @@ done:
     msg->narg_end = NULL;
     msg->narg = 0;
     msg->rnarg = 0;
+    msg->depth = 0;
     msg->rlen = 0;
     msg->integer = 0;
 

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -34,6 +34,8 @@ typedef enum msg_parse_result {
     MSG_PARSE_AGAIN,                      /* incomplete -> parse again */
 } msg_parse_result_t;
 
+#define NC_MULTIBULK_DEPTH               3
+
 #define MSG_TYPE_CODEC(ACTION)                                                                      \
     ACTION( UNKNOWN )                                                                               \
     ACTION( REQ_MC_GET )                       /* memcache retrieval requests */                    \
@@ -161,11 +163,16 @@ typedef enum msg_parse_result {
     ACTION( REQ_REDIS_ZSCORE )                                                                      \
     ACTION( REQ_REDIS_ZUNIONSTORE )                                                                 \
     ACTION( REQ_REDIS_ZSCAN)                                                                        \
+    ACTION( REQ_REDIS_GEOADD )                                                                        \
+    ACTION( REQ_REDIS_GEOHASH )                                                                        \
+    ACTION( REQ_REDIS_GEODIST )                                                                        \
+    ACTION( REQ_REDIS_GEORADIUS )                                                                        \
+    ACTION( REQ_REDIS_GEORADIUSBYMEMBER )                                                                        \
     ACTION( REQ_REDIS_EVAL )                   /* redis requests - eval */                          \
     ACTION( REQ_REDIS_EVALSHA )                                                                     \
     ACTION( REQ_REDIS_PING )                   /* redis requests - ping/quit */                     \
-    ACTION( REQ_REDIS_QUIT)                                                                         \
-    ACTION( REQ_REDIS_AUTH)                                                                         \
+    ACTION( REQ_REDIS_QUIT )                                                                         \
+    ACTION( REQ_REDIS_AUTH )                                                                         \
     ACTION( REQ_REDIS_SELECT)                  /* only during init */                               \
     ACTION( RSP_REDIS_STATUS )                 /* redis response */                                 \
     ACTION( RSP_REDIS_ERROR )                                                                       \
@@ -214,6 +221,7 @@ struct msg {
     uint32_t             mlen;            /* message length */
     int64_t              start_ts;        /* request start timestamp in usec */
 
+    int                  depth;
     int                  state;           /* current parser state */
     uint8_t              *pos;            /* parser position marker */
     uint8_t              *token;          /* token marker */
@@ -240,6 +248,7 @@ struct msg {
     uint8_t              *narg_end;       /* narg end (redis) */
     uint32_t             narg;            /* # arguments (redis) */
     uint32_t             rnarg;           /* running # arg used by parsing fsa (redis) */
+    uint32_t             rnargs[NC_MULTIBULK_DEPTH];           /* running # arg used by parsing fsa (redis) */
     uint32_t             rlen;            /* running length in parsing fsa (redis) */
     uint32_t             integer;         /* integer reply value (redis) */
 

--- a/src/proto/nc_proto.h
+++ b/src/proto/nc_proto.h
@@ -138,6 +138,10 @@
     (str15icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14) &&       \
      (m[15] == c15 || m[15] == (c15 ^ 0x20)))
 
+#define str17icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16)  \
+    (str16icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15) &&       \
+     (m[16] == c16 || m[16] == (c16 ^ 0x20)))
+
 void memcache_parse_req(struct msg *r);
 void memcache_parse_rsp(struct msg *r);
 bool memcache_failure(struct msg *r);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1718,15 +1718,16 @@ error:
                 r->state);
 }
 
-static int update_and_check_done(struct msg *r) {
-    int ret = 0;
+static bool
+redis_update_and_check_done(struct msg *r) {
+    bool ret = false;
     while(r->rnarg == 0 && r->depth > 0) {
         r->depth--;
         r->rnarg = r->rnargs[r->depth]-1;
     }
 
     if (r->rnarg == 0 && r->depth == 0) {
-        ret = 1;
+        ret = true;
     }
 
     return ret;
@@ -2081,7 +2082,7 @@ redis_parse_rsp(struct msg *r)
             switch (ch) {
             case LF:
                 if (r->depth > 0) {
-                    if (update_and_check_done(r) == true) {
+                    if (redis_update_and_check_done(r) == true) {
                         goto done;
                     }
                 } else {
@@ -2131,7 +2132,7 @@ redis_parse_rsp(struct msg *r)
                 if (r->rnarg == 0) {
                     /* response is '*0\r\n' */
                     if (r->depth > 0) {
-                        if (update_and_check_done(r) == 1) {
+                        if (redis_update_and_check_done(r) == true) {
                             goto error;
                         }
                     } else {
@@ -2279,7 +2280,7 @@ redis_parse_rsp(struct msg *r)
             case LF:
                 if (r->rnarg == 0) {
                     if (r->depth > 0) {
-                        if (update_and_check_done(r) == 1) {
+                        if (redis_update_and_check_done(r) == true) {
                             goto done;
                         }
                     } else {


### PR DESCRIPTION
1. support GEO Commands
   -> geoadd, geohash, geodist, georadius, georadiusbymember
2. support nested multibulk reply
   -> geo commands return nested multibulk reply

currently we only support this type of multibulk

```
                 * - mulit-bulk
                 *    - cursor
                 *    - mulit-bulk
                 *       - val1
                 *       - val2
                 *       - val3
```

but georadius and georadiusbymember returns maximum 3 depth multibulk. so this patch supports this kind of multibulk also.

```
                 * - mulit-bulk
                 *    - multi-bulk
                 *       - val1
                 *       - val2
                 *       - val3
                 *    - mulit-bulk
                 *       - val1
                 *       - val2
                 *       - val3
                 *
                 * - mulit-bulk
                 *    - multi-bulk
                 *       - val1
                 *       - multi-bulk
                 *          - val2
                 *          - val3
                 *    - mulit-bulk
                 *       - val1
                 *       - multi-bulk
                 *          - val2
                 *          - val3
```
