### PR TITLE
Document the client_connections config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Furthermore, memory for mbufs is managed using a reuse pool. This means that onc
 Twemproxy can be configured through a YAML file specified by the -c or --conf-file command-line argument on process start. The configuration file is used to specify the server pools and the servers within each pool that twemproxy manages. The configuration files parses and understands the following keys:
 
 + **listen**: The listening address and port (name:port or ip:port) or an absolute path to sock file (e.g. /var/run/nutcracker.sock) for this server pool.
++ **client_connections**: The maximum number of connections allowed from redis clients. Unlimited by default, though OS-imposed limitations will still apply.
 + **hash**: The name of the hash function. Possible values are:
  + one_at_a_time
  + md5


### PR DESCRIPTION
We're using this setting, so thought it should be documented.

I had a very quick look at the code and couldn't immediately see where there's a check that the number of connections isn't exceeded, but I assume it's in there somewhere!