### PR TITLE
Removing duplicate Hootsuite mention in list of companies using Twemproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ https://launchpad.net/~twemproxy/+archive/ubuntu/daily
 + [Ooyala](http://www.ooyala.com)
 + [Twitch](http://twitch.tv)
 + [Socrata](http://www.socrata.com/)
-+ [Hootsuite](http://hootsuite.com/)
++ [Hootsuite](https://hootsuite.com/) ([details](http://code.hootsuite.com/mysql-to-redis/))
 + [Trivago](http://www.trivago.com/)
 + [Machinezone](http://www.machinezone.com)
 + [Path](https://path.com)
@@ -289,7 +289,6 @@ https://launchpad.net/~twemproxy/+archive/ubuntu/daily
 + [Poshmark](https://poshmark.com/)
 + [FanDuel](https://www.fanduel.com/)
 + [Bloomreach](http://bloomreach.com/)
-+ [Hootsuite](https://hootsuite.com)
 + [Tradesy](https://www.tradesy.com/)
 
 ## Issues and Support


### PR DESCRIPTION
Hootsuite was added twice: in #291 and #387.

PS. Maybe it's good to sort companies list alphabetically to prevent such duplication in future. I can do it if you agree.
