### PR TITLE
Allow ignoring SELECT from client

### DIFF
--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -86,6 +86,10 @@ static struct command conf_commands[] = {
       conf_set_num,
       offsetof(struct conf_pool, redis_db) },
 
+    { string("redis_ignore_select"),
+      conf_set_bool,
+      offsetof(struct conf_pool, redis_ignore_select) },
+
     { string("preconnect"),
       conf_set_bool,
       offsetof(struct conf_pool, preconnect) },
@@ -200,6 +204,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
     cp->redis = CONF_UNSET_NUM;
     cp->tcpkeepalive = CONF_UNSET_NUM;
     cp->redis_db = CONF_UNSET_NUM;
+    cp->redis_ignore_select = CONF_UNSET_NUM;
     cp->preconnect = CONF_UNSET_NUM;
     cp->auto_eject_hosts = CONF_UNSET_NUM;
     cp->server_connections = CONF_UNSET_NUM;
@@ -292,6 +297,7 @@ conf_pool_each_transform(void *elem, void *data)
     sp->timeout = cp->timeout;
     sp->backlog = cp->backlog;
     sp->redis_db = cp->redis_db;
+    sp->redis_ignore_select = cp->redis_ignore_select ? 1 : 0;
 
     sp->redis_auth = cp->redis_auth;
     sp->require_auth = cp->redis_auth.len > 0 ? 1 : 0;
@@ -1244,6 +1250,10 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
 
     if (cp->redis_db == CONF_UNSET_NUM) {
         cp->redis_db = CONF_DEFAULT_REDIS_DB;
+    }
+    
+    if (cp->redis_ignore_select == CONF_UNSET_NUM) {
+        cp->redis_ignore_select = CONF_DEFAULT_REDIS_IGNORE_SELECT;
     }
 
     if (cp->preconnect == CONF_UNSET_NUM) {

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -48,6 +48,7 @@
 #define CONF_DEFAULT_CLIENT_CONNECTIONS      0
 #define CONF_DEFAULT_REDIS                   false
 #define CONF_DEFAULT_REDIS_DB                0
+#define CONF_DEFAULT_REDIS_IGNORE_SELECT     false
 #define CONF_DEFAULT_PRECONNECT              false
 #define CONF_DEFAULT_AUTO_EJECT_HOSTS        false
 #define CONF_DEFAULT_SERVER_RETRY_TIMEOUT    30 * 1000      /* in msec */
@@ -88,6 +89,7 @@ struct conf_pool {
     int                redis;                 /* redis: */
     struct string      redis_auth;            /* redis_auth: redis auth password (matches requirepass on redis) */
     int                redis_db;              /* redis_db: redis db */
+    int                redis_ignore_select;   /* redis_ignore_select: whether to ignore selects and just reply ok */
     int                preconnect;            /* preconnect: */
     int                auto_eject_hosts;      /* auto_eject_hosts: */
     int                server_connections;    /* server_connections: */

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -121,6 +121,7 @@ struct server_pool {
     unsigned           preconnect:1;         /* preconnect? */
     unsigned           redis:1;              /* redis? */
     unsigned           tcpkeepalive:1;       /* tcpkeepalive? */
+    unsigned           redis_ignore_select:1;/* redis ignore select? */
 };
 
 void server_ref(struct conn *conn, void *owner);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -62,6 +62,8 @@ static bool
 redis_arg0(struct msg *r)
 {
     switch (r->type) {
+    case MSG_REQ_REDIS_SELECT:
+
     case MSG_REQ_REDIS_EXISTS:
     case MSG_REQ_REDIS_PERSIST:
     case MSG_REQ_REDIS_PTTL:
@@ -106,7 +108,7 @@ redis_arg0(struct msg *r)
 static bool
 redis_arg1(struct msg *r)
 {
-    switch (r->type) {
+    switch (r->type) {      
     case MSG_REQ_REDIS_EXPIRE:
     case MSG_REQ_REDIS_EXPIREAT:
     case MSG_REQ_REDIS_PEXPIRE:
@@ -876,6 +878,12 @@ redis_parse_req(struct msg *r)
 
                 if (str6icmp(m, 'z', 's', 'c', 'o', 'r', 'e')) {
                     r->type = MSG_REQ_REDIS_ZSCORE;
+                    break;
+                }
+		
+		if (str6icmp(m, 's', 'e', 'l', 'e', 'c', 't')) {
+                    r->type = MSG_REQ_REDIS_SELECT;
+                    r->noforward = 1;
                     break;
                 }
 
@@ -2680,6 +2688,7 @@ redis_reply(struct msg *r)
 {
     struct conn *c_conn;
     struct msg *response = r->peer;
+    struct server_pool *pool;
 
     ASSERT(response != NULL && response->owner != NULL);
 
@@ -2695,7 +2704,11 @@ redis_reply(struct msg *r)
     switch (r->type) {
     case MSG_REQ_REDIS_PING:
         return msg_append(response, rsp_pong.data, rsp_pong.len);
-
+    case MSG_REQ_REDIS_SELECT:
+        pool = (struct server_pool *)c_conn->owner;
+	if (pool->redis_ignore_select) {
+            return msg_append(response, rsp_ok.data, rsp_ok.len);
+	}
     default:
         NOT_REACHED();
         return NC_ERROR;


### PR DESCRIPTION
Even if you are just using database 0, some developers want to call Redis' SELECT command always up front. This add a new redis_ignore_select option to pools to simply return OK for any SELECT command.