### PR TITLE
Implement ERROR protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 *.~
 *.project
 *.cproject
+.settings/
 
 # Core and executable
 core*

--- a/src/hashkit/nc_one_at_a_time.c
+++ b/src/hashkit/nc_one_at_a_time.c
@@ -38,8 +38,10 @@ hash_one_at_a_time(const char *key, size_t key_length)
     uint32_t value = 0;
 
     if (key == NULL) {
-        return NULL;
+        return 0;
     }
+
+    //log_error("key is %s", key);
 
     while (key_length--) {
         uint32_t val = (uint32_t) *ptr++;

--- a/src/hashkit/nc_one_at_a_time.c
+++ b/src/hashkit/nc_one_at_a_time.c
@@ -37,12 +37,6 @@ hash_one_at_a_time(const char *key, size_t key_length)
     const char *ptr = key;
     uint32_t value = 0;
 
-    if (key == NULL) {
-        return 0;
-    }
-
-    //log_error("key is %s", key);
-
     while (key_length--) {
         uint32_t val = (uint32_t) *ptr++;
         value += val;

--- a/src/hashkit/nc_one_at_a_time.c
+++ b/src/hashkit/nc_one_at_a_time.c
@@ -37,6 +37,10 @@ hash_one_at_a_time(const char *key, size_t key_length)
     const char *ptr = key;
     uint32_t value = 0;
 
+    if (key == NULL) {
+        return NULL;
+    }
+
     while (key_length--) {
         uint32_t val = (uint32_t) *ptr++;
         value += val;

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -334,7 +334,8 @@ core_core(void *arg, uint32_t events)
     /* read takes precedence over write */
     if (events & EVENT_READ) {
         status = core_recv(ctx, conn);
-        if (status != NC_OK || conn->done || conn->err) {
+
+        if (conn->done) {
             core_close(ctx, conn);
             return NC_ERROR;
         }

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -650,6 +650,11 @@ msg_parse(struct context *ctx, struct conn *conn, struct msg *msg)
         status = NC_OK;
         break;
 
+    case MSG_PARSE_ERROR:
+		status = NC_ERROR;
+		conn->recv_done(ctx, conn, msg, NULL);;
+		break;
+
     default:
         status = NC_ERROR;
         conn->err = errno;


### PR DESCRIPTION
Rather than severing connections upon an invalid event, this patch adds the ERROR portion of the Memcached protocol.  This does not, however, add CLIENT_ERROR or SERVER_ERROR.  That can be discussed.
