### PR TITLE
Allow negative exptime values in memcached storage commands

### DIFF
--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -435,7 +435,7 @@ memcache_parse_req(struct msg *r)
 
         case SW_SPACES_BEFORE_EXPIRY:
             if (ch != ' ') {
-                if (!isdigit(ch)) {
+                if (!(isdigit(ch) || ch == '-')) {
                     goto error;
                 }
                 /* expiry_start <- p; expiry <- ch - '0' */


### PR DESCRIPTION
Memcached allows negative exptime values in storage commands to immediately expire the stored values, but this wasn't very well documented until recently (here's the commit that adds the documentation from May 2016: https://github.com/memcached/memcached/commit/e7d4521cd8b27f7ebc6e4c1b9aee9eb3544f6af5).

This patch allows the memcached parser to support negative exptime values in storage commands.



