### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc
+
+COPY . /usr/src/twemproxy
+WORKDIR /usr/src/twemproxy
+RUN \
+  autoreconf -h && \
+  autoreconf -fvi && \
+  ./configure && \
+  make && \
+  make install
+
+ENTRYPOINT [ "nutcracker" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official GCC image, latest tag. More info at https://hub.docker.com/_/gcc/

Just adding files, setting working dir and running make instructions.

Build:

```
$ docker build -t twemproxy .
```

Run:

```
$ docker run --rm -it -p [ext_port1:port1] -p [ext_port2:port2] -p [...] -v [your_host_config_yml]:/etc/nutcracker.yml:ro twemproxy -c /etc/nutcracker.yml --verbose=6 [other options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -p [ext_port1:port1] -p [ext_port2:port2] -p [...] -v [your_host_config_yml]:/etc/nutcracker.yml:ro pataquets/twemproxy  -c /etc/nutcracker.yml --verbose=6 [other options...]
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it.
In order for the Docker container to connect to external memcached or Redis instances, either them should be contactable as external IPs or hosts or be linked to other previously run Docker containers via Docker's ```--link``` option.

Here it is an example Docker Compose file I'm using (I can submit it with the PR also if you find it useful):
```
redis1:
  image: redis:3.2
  command: --save "" --maxmemory 128mb
  ports:
    - 63791:6379

redis2:
  image: redis:3.2
  command: --save "" --maxmemory 128mb
  ports:
    - 63792:6379

twemproxy:
  image: pataquets/twemproxy
  command: -c /etc/nutcracker.yml --verbose=6
  links:
    - redis1
    - redis2
  ports:
    - 6379:6379
    - 22222:22222
  volumes:
    - ./conf/nutcracker.redis.yml:/etc/nutcracker.yml:ro
```
Notice that it is tuned for two Redis instances (yml file not included, mount yours)

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.