### PR TITLE
Always initialize file permissions field for unix domain socket

### DIFF
--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -1474,6 +1474,7 @@ conf_set_listen(struct conf *cf, struct command *cmd, void *conf)
             /* no permissions field, so use defaults */
             name = value->data;
             namelen = value->len;
+            field->perm = (mode_t)0;
         } else {
             perm = q + 1;
             permlen = (uint32_t)(p - perm + 1);


### PR DESCRIPTION
It seems like field->perm might be uninitialized memory
depending on how it is allocated.
The intended behavior is to only change file permissions from the default if a permission was specified in the config:
https://github.com/twitter/twemproxy/pull/311/files#diff-f74ea9da930e79a9573455a0cbe4785d

I ran into an issue where different sockets had different file
permissions, and some of those sockets weren't readable by the user
which created it. (I specified *only* the path to the unix domain socket)

This behavior probably started in
https://github.com/twitter/twemproxy/pull/311/files