### PR TITLE
putting a check if a process exited

### DIFF
--- a/scripts/nutcracker.init.debian
+++ b/scripts/nutcracker.init.debian
@@ -51,7 +51,7 @@ do_start()
 do_stop()
 {
     echo -n "Stopping ${NAME}: "
-    start-stop-daemon --stop --quiet --pidfile $PIDFILE --exec $DAEMON || true
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/2 --pidfile $PIDFILE --exec $DAEMON || true
 
     case "$?" in
         0|1) echo "STOPPED.";;


### PR DESCRIPTION
Under restart the init script is stopping the process and starting it again. 
When stopping it does not wait and issues a SIGTERM to the process, this causes trouble when the server was not able to shutdown within a minuscule time and a start was issued.
The same thing we encountered in production where under restart the server was not able to stop and a start was issued.
Logs:
[2018-01-30 15:40:45.198] nc.c:187 nutcracker-0.4.0 built for Linux 3.16.0-4-amd64 x86_64 started on pid 66313
[2018-01-30 15:40:45.199] nc.c:192 run, rabbit run / dig that hole, forget the sun / and when at last the work is done / don't sit down / it's time to dig another one
[2018-01-30 15:40:45.203] nc_stats.c:840 bind on m 4 to addr '0.0.0.0:15050' failed: Address already in use

Fix:
===
Waiting for the process to end and then issuing Kill if it didn't stop.

