### PR TITLE
Summary: this PR intends to make twemporxy able to parse nested multibulks

### DIFF
--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -255,6 +255,8 @@ done:
     msg->narg_end = NULL;
     msg->narg = 0;
     msg->rnarg = 0;
+    memset(msg->stack, 0, sizeof(msg->stack));
+    msg->nested_depth = 0;
     msg->rlen = 0;
     msg->integer = 0;
 

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -20,6 +20,8 @@
 
 #include <nc_core.h>
 
+#define MAXDEPTH 3
+
 typedef void (*msg_parse_t)(struct msg *);
 typedef rstatus_t (*msg_add_auth_t)(struct context *ctx, struct conn *c_conn, struct conn *s_conn);
 typedef rstatus_t (*msg_fragment_t)(struct msg *, uint32_t, struct msg_tqh *);
@@ -160,7 +162,13 @@ typedef enum msg_parse_result {
     ACTION( REQ_REDIS_ZREVRANK )                                                                    \
     ACTION( REQ_REDIS_ZSCORE )                                                                      \
     ACTION( REQ_REDIS_ZUNIONSTORE )                                                                 \
-    ACTION( REQ_REDIS_ZSCAN)                                                                        \
+    ACTION( REQ_REDIS_ZSCAN )                                                                       \
+    ACTION( REQ_REDIS_GEOADD ) 									    \
+    ACTION( REQ_REDIS_GEOPOS )									    \
+    ACTION( REQ_REDIS_GEOHASH )									    \
+    ACTION( REQ_REDIS_GEODIST )									    \
+    ACTION( REQ_REDIS_GEORADIUS )                                                                   \
+    ACTION( REQ_REDIS_GEORADIUSBYMEMBER )                                                           \
     ACTION( REQ_REDIS_EVAL )                   /* redis requests - eval */                          \
     ACTION( REQ_REDIS_EVALSHA )                                                                     \
     ACTION( REQ_REDIS_PING )                   /* redis requests - ping/quit */                     \
@@ -240,6 +248,8 @@ struct msg {
     uint8_t              *narg_end;       /* narg end (redis) */
     uint32_t             narg;            /* # arguments (redis) */
     uint32_t             rnarg;           /* running # arg used by parsing fsa (redis) */
+    uint32_t             stack[MAXDEPTH]; /* stack to save rnarg of nesting multibulks */
+    uint8_t              nested_depth;    /* the depth of the current nested multibulk */
     uint32_t             rlen;            /* running length in parsing fsa (redis) */
     uint32_t             integer;         /* integer reply value (redis) */
 

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -20,7 +20,7 @@
 
 #include <nc_core.h>
 
-#define MAXDEPTH 3
+#define MAXDEPTH 4
 
 typedef void (*msg_parse_t)(struct msg *);
 typedef rstatus_t (*msg_add_auth_t)(struct context *ctx, struct conn *c_conn, struct conn *s_conn);

--- a/src/proto/nc_proto.h
+++ b/src/proto/nc_proto.h
@@ -22,121 +22,125 @@
 
 #ifdef NC_LITTLE_ENDIAN
 
-#define str4cmp(m, c0, c1, c2, c3)                                                          \
+#define str4cmp(m, c0, c1, c2, c3)                                                               \
     (*(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0))
 
-#define str5cmp(m, c0, c1, c2, c3, c4)                                                      \
+#define str5cmp(m, c0, c1, c2, c3, c4)                                                           \
     (str4cmp(m, c0, c1, c2, c3) && (m[4] == c4))
 
-#define str6cmp(m, c0, c1, c2, c3, c4, c5)                                                  \
-    (str4cmp(m, c0, c1, c2, c3) &&                                                          \
+#define str6cmp(m, c0, c1, c2, c3, c4, c5)                                                       \
+    (str4cmp(m, c0, c1, c2, c3) &&                                                               \
         (((uint32_t *) m)[1] & 0xffff) == ((c5 << 8) | c4))
 
-#define str7cmp(m, c0, c1, c2, c3, c4, c5, c6)                                              \
+#define str7cmp(m, c0, c1, c2, c3, c4, c5, c6)                                                   \
     (str6cmp(m, c0, c1, c2, c3, c4, c5) && (m[6] == c6))
 
-#define str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                                          \
-    (str4cmp(m, c0, c1, c2, c3) &&                                                          \
+#define str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                                               \
+    (str4cmp(m, c0, c1, c2, c3) &&                                                               \
         (((uint32_t *) m)[1] == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4)))
 
-#define str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                                      \
+#define str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                                           \
     (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) && m[8] == c8)
 
-#define str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                                 \
-    (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                                          \
+#define str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                                      \
+    (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                                               \
         (((uint32_t *) m)[2] & 0xffff) == ((c9 << 8) | c8))
 
-#define str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)                            \
+#define str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)                                 \
     (str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9) && (m[10] == c10))
 
-#define str12cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)                       \
-    (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                                          \
+#define str12cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)                            \
+    (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                                               \
         (((uint32_t *) m)[2] == ((c11 << 24) | (c10 << 16) | (c9 << 8) | c8)))
 
 #else
 
-#define str4cmp(m, c0, c1, c2, c3)                                                          \
+#define str4cmp(m, c0, c1, c2, c3)                                                               \
     (m[0] == c0 && m[1] == c1 && m[2] == c2 && m[3] == c3)
 
-#define str5cmp(m, c0, c1, c2, c3, c4)                                                      \
+#define str5cmp(m, c0, c1, c2, c3, c4)                                                           \
     (str4cmp(m, c0, c1, c2, c3) && (m[4] == c4))
 
-#define str6cmp(m, c0, c1, c2, c3, c4, c5)                                                  \
+#define str6cmp(m, c0, c1, c2, c3, c4, c5)                                                       \
     (str5cmp(m, c0, c1, c2, c3, c4) && m[5] == c5)
 
-#define str7cmp(m, c0, c1, c2, c3, c4, c5, c6)                                              \
+#define str7cmp(m, c0, c1, c2, c3, c4, c5, c6)                                                   \
     (str6cmp(m, c0, c1, c2, c3, c4, c5) && m[6] == c6)
 
-#define str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                                          \
+#define str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                                               \
     (str7cmp(m, c0, c1, c2, c3, c4, c5, c6) && m[7] == c7)
 
-#define str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                                      \
+#define str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                                           \
     (str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7) && m[8] == c8)
 
-#define str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                                 \
+#define str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                                      \
     (str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8) && m[9] == c9)
 
-#define str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)                            \
+#define str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)                                 \
     (str10cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9) && m[10] == c10)
 
-#define str12cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)                       \
+#define str12cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)                            \
     (str11cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) && m[11] == c11)
 
 #endif
 
-#define str3icmp(m, c0, c1, c2)                                                             \
-    ((m[0] == c0 || m[0] == (c0 ^ 0x20)) &&                                                 \
-     (m[1] == c1 || m[1] == (c1 ^ 0x20)) &&                                                 \
+#define str3icmp(m, c0, c1, c2)                                                                  \
+    ((m[0] == c0 || m[0] == (c0 ^ 0x20)) &&                                                      \
+     (m[1] == c1 || m[1] == (c1 ^ 0x20)) &&                                                      \
      (m[2] == c2 || m[2] == (c2 ^ 0x20)))
 
-#define str4icmp(m, c0, c1, c2, c3)                                                         \
+#define str4icmp(m, c0, c1, c2, c3)                                                              \
     (str3icmp(m, c0, c1, c2) && (m[3] == c3 || m[3] == (c3 ^ 0x20)))
 
-#define str5icmp(m, c0, c1, c2, c3, c4)                                                     \
+#define str5icmp(m, c0, c1, c2, c3, c4)                                                          \
     (str4icmp(m, c0, c1, c2, c3) && (m[4] == c4 || m[4] == (c4 ^ 0x20)))
 
-#define str6icmp(m, c0, c1, c2, c3, c4, c5)                                                 \
+#define str6icmp(m, c0, c1, c2, c3, c4, c5)                                                      \
     (str5icmp(m, c0, c1, c2, c3, c4) && (m[5] == c5 || m[5] == (c5 ^ 0x20)))
 
-#define str7icmp(m, c0, c1, c2, c3, c4, c5, c6)                                             \
-    (str6icmp(m, c0, c1, c2, c3, c4, c5) &&                                                 \
+#define str7icmp(m, c0, c1, c2, c3, c4, c5, c6)                                                  \
+    (str6icmp(m, c0, c1, c2, c3, c4, c5) &&                                                      \
      (m[6] == c6 || m[6] == (c6 ^ 0x20)))
 
-#define str8icmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                                         \
-    (str7icmp(m, c0, c1, c2, c3, c4, c5, c6) &&                                             \
+#define str8icmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                                              \
+    (str7icmp(m, c0, c1, c2, c3, c4, c5, c6) &&                                                  \
      (m[7] == c7 || m[7] == (c7 ^ 0x20)))
 
-#define str9icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                                     \
-    (str8icmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                                         \
+#define str9icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                                          \
+    (str8icmp(m, c0, c1, c2, c3, c4, c5, c6, c7) &&                                              \
      (m[8] == c8 || m[8] == (c8 ^ 0x20)))
 
-#define str10icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                                \
-    (str9icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8) &&                                     \
+#define str10icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)                                     \
+    (str9icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8) &&                                          \
      (m[9] == c9 || m[9] == (c9 ^ 0x20)))
 
-#define str11icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)                           \
-    (str10icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9) &&                                \
+#define str11icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)                                \
+    (str10icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9) &&                                     \
      (m[10] == c10 || m[10] == (c10 ^ 0x20)))
 
-#define str12icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)                      \
-    (str11icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) &&                           \
+#define str12icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)                           \
+    (str11icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) &&                                \
      (m[11] == c11 || m[11] == (c11 ^ 0x20)))
 
-#define str13icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12)                 \
-    (str12icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11) &&                      \
+#define str13icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12)                      \
+    (str12icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11) &&                           \
      (m[12] == c12 || m[12] == (c12 ^ 0x20)))
 
-#define str14icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13)            \
-    (str13icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12) &&                 \
+#define str14icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13)                 \
+    (str13icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12) &&                      \
      (m[13] == c13 || m[13] == (c13 ^ 0x20)))
 
-#define str15icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14)       \
-    (str14icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13) &&            \
+#define str15icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14)            \
+    (str14icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13) &&                 \
      (m[14] == c14 || m[14] == (c14 ^ 0x20)))
 
-#define str16icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15)  \
-    (str15icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14) &&       \
+#define str16icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15)       \
+    (str15icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14) &&            \
      (m[15] == c15 || m[15] == (c15 ^ 0x20)))
+
+#define str17icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16)  \
+    (str16icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15) &&       \
+     (m[16] == c16 || m[16] == (c16 ^ 0x20)))
 
 void memcache_parse_req(struct msg *r);
 void memcache_parse_rsp(struct msg *r);

--- a/tests/test_redis/test_geo.py
+++ b/tests/test_redis/test_geo.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#coding: utf-8
+
+from common import *
+
+def geoadd():
+    r = getconn()
+    rst = r.geoadd("Sicily", 13.361389, 38.115556, "Palermo",
+            15.087269, 37.502669, "Catania")
+    assert(rst == 2)
+
+    return r
+
+def test_geodist():
+    r = geoadd()
+    assert(r.geodist("Sicily", "Palermo",  "Catania") == 166274.1516)
+    assert(r.geodist("Sicily", "Palermo", "Catania", "km") == 166.2742)
+    assert(r.geodist("Sicily", "Palermo", "Catania", "mi") == 103.3182)
+    assert(r.geodist("Sicily", "Foo", "Bar") == None)
+    assert(r.geodist("Shenzhen", "Nanshan", "Futian") == None)
+
+def test_geohash():
+    r = geoadd()
+    rst = r.geohash("Sicily", "Palermo", "Catania")
+    assert(rst == ["sqc8b49rny0", "sqdtr74hyu0"])
+
+def test_geopos():
+    r = geoadd()
+    rst = r.geopos("Sicily", "Palermo", "Catania", "NonExisting")
+    assert(rst == [(13.36138933897018433, 38.11555639549629859), 
+                   (15.08726745843887329, 37.50266842333162032),
+                   None])
+    rst = r.geopos("Shenzhen", "Nanshan", "Futian", "Bao'an")
+    assert(rst == [None, None, None])
+
+def test_georadius():
+    r = geoadd()
+    rst = r.georadius("Sicily",15, 37, 200, "km", withdist=True)
+    assert(rst == [["Palermo", 190.4424], ["Catania", 56.4413]])
+
+    rst = r.georadius("Sicily", 15, 37, 200, "km", withcoord=True)
+    assert(rst == [["Palermo", (13.36138933897018433, 38.11555639549629859)],
+                   ["Catania", (15.08726745843887329, 37.50266842333162032)]])
+
+    rst = r.georadius("Sicily", 15, 37, 200, "km", withhash=True)
+    assert(rst == [["Palermo", 3479099956230698], ["Catania", 3479447370796909]])
+
+    rst = r.georadius("Sicily", 15, 37, 200, "km",
+            withdist=True, withcoord=True, withhash=True)
+    assert(rst == [["Palermo", 190.4424, 3479099956230698,
+                    (13.36138933897018433, 38.11555639549629859)],
+                   ["Catania", 56.4413, 3479447370796909,
+                    (15.08726745843887329, 37.50266842333162032)]])
+
+    rst = r.georadius("Shenzhen", 15, 37, 200, "km",
+            withdist=True, withcoord=True, withhash=True)
+    assert(rst == [])
+
+def test_georadiusbymember():
+    r = geoadd()
+    assert(r.geoadd("Sicily", 13.583333, 37.316667, "Agrigento") == 1)
+    rst = r.georadiusbymember("Sicily", "Agrigento", 100, "km")
+    assert(rst == ["Agrigento", "Palermo"])
+    rst = r.georadiusbymember("Shenzhen", "Agrigento", 100, "km")
+    assert(rst == [])
+    assert_fail("could not decode requested zset member",
+                r.georadiusbymember, "Sicily", "Nanshan", 100, "km")


### PR DESCRIPTION
i.e. the response of georadiuswithcoord. 

Problem

 twemporxy is not able to parse nested multibulks reponse, which is not necessary before geo introduced but now we need it.  Instead of using an ad hoc hack to parse the response of geo  command, i.e. georadiuswithcoord, it would be better to have a generic approach support any syntactically correct redis response of multibulks, which can make  twemproxy work with new redis commands at no cost in the future. 

Solution

This is achieved by introducing a small stack in struct msg, this stack remembers the number of arguments to be parsed of current multibulk and all nesting multibulks.   Changes only affect the parse path of multinulk response, and everything else is untouched. 

to test geodist between nonexisting members of a zset, checkout this PR: https://github.com/andymccurdy/redis-py/pull/1035 to make the test work.

Result

This PR make twemproxy work with all geo commands.  I have a in house redis-server which can produce  multibulk responses of various combinations, and my twemproxy instance with this patch is happy with them.  here are the  response combinations(with the max depth of 3, and testmultibulk 6  with a depth of 4)

127.0.0.1:55555> testmultibulk 0
(empty list or set)

127.0.0.1:55555> testmultibulk 1
1) (nil)
2) (integer) 666

127.0.0.1:55555> testmultibulk 2
1) (empty list or set)

127.0.0.1:55555> testmultibulk 3
1) (nil)
2) (integer) 666
3) 1) (nil)
   2) "hello"

127.0.0.1:55555> testmultibulk 4
1) (nil)
2) (nil)
3) (integer) 666
4) 1) 1) "biubiubiu"
   2) 1) (nil)
   3) 1) OK

127.0.0.1:55555> testmultibulk 5
1) (nil)
2) (nil)
3) (integer) 666
4) 1) 1) "biubiubiu"
   2) 1) (nil)
   3) OK
5) 1) (integer) 666
   2) (error) OOM command not allowed when used memory > 'maxmemory'.
   3) OK

127.0.0.1:55555> testmultibulk 6 
(error) ERR Invalid argument

127.0.0.1:55555> testmultibulk 7
1) (nil)
2) (nil)
3) (integer) 666
4) 1) 1) "biubiubiu"
   2) 1) (nil)
   3) OK
5) 1) (integer) 666
   2) (error) OOM command not allowed when used memory > 'maxmemory'.
   3) OK
6) 1) 1) OK
7) 1) (empty list or set)
   2) (empty list or set)
   3) (empty list or set)