### PR TITLE
Fix parsing of redis error message without space

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,24 @@
+ 2021-??-??  Tyson Andre
+    * twemproxy: version 0.4.2 release (dev)
+	  Fix parsing of redis error response for error type with no space,
+	  add tests (tyson, tom dalton)
+	  Update integration tests, add C unit test suite for 'make check' (tyson)
+	  Increase the maximum host length+port+identifier to 273
+	  in ketama_update (李广博)
+	  Always initialize file permissions field when listening on a unix domain
+	  socket (tyson)
+	  Use number of servers instead of number of points on the continuum when
+	  sharding requests to backend services to improve sharding performance
+	  and fix potential invalid memory access when all hosts were ejected
+	  from a pool. (tyson)
+	  Don't fragment memcache/redis get commands when they only have a single
+	  key (improves performance and error handling of single key case) (tyson)
+	  Don't let requests hang when there is a dns error when processing a
+	  fragmented request (e.g. multiget with multiple keys) (tyson)
+	  Allow extra parameters for redis spop (charsyam)
+	  Update documentation and README (various)
+	  Fix memory leak bug for redis mset (deep011)
+
  2015-22-06  Manju Rajashekhar  <manj@cs.stanford.edu>
     * twemproxy: version 0.4.1 release
       backend server hostnames are resolved lazily

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1920,7 +1920,12 @@ redis_parse_rsp(struct msg *r)
 
                     break;
                 }
-                state = SW_RUNTO_CRLF;
+                if (ch == '\r') {
+                    state = SW_ALMOST_DONE;
+                } else {
+                    /* Read remaining characters until '\r' */
+                    state = SW_RUNTO_CRLF;
+                }
             }
 
             break;
@@ -2101,9 +2106,9 @@ redis_parse_rsp(struct msg *r)
                  * there is a special case for sscan/hscan/zscan, these command
                  * replay a nested multi-bulk with a number and a multi bulk like this:
                  *
-                 * - mulit-bulk
+                 * - multi-bulk
                  *    - cursor
-                 *    - mulit-bulk
+                 *    - multi-bulk
                  *       - val1
                  *       - val2
                  *       - val3

--- a/src/test_all.c
+++ b/src/test_all.c
@@ -2,6 +2,7 @@
 #include <nc_conf.h>
 #include <nc_util.h>
 #include <proto/nc_proto.h>
+#include <stdio.h>
 
 static int failures = 0;
 static int successes = 0;
@@ -16,7 +17,7 @@ static void expect_same_uint32_t(uint32_t expected, uint32_t actual, const char*
     }
 }
 
-static void expect_same_ptr(void *expected, void *actual, const char* message) {
+static void expect_same_ptr(const void *expected, const void *actual, const char* message) {
     if (expected != actual) {
         printf("FAIL Expected %p, got %p (%s)\n", expected, actual, message);
         failures++;
@@ -121,6 +122,7 @@ static void test_redis_parse_rsp_success_case(char* data) {
 
 /* Test support for https://redis.io/topics/protocol */
 static void test_redis_parse_rsp_success(void) {
+    test_redis_parse_rsp_success_case("-CUSTOMERR\r\n");  /* Error message without a space */
     test_redis_parse_rsp_success_case("-Error message\r\n");  /* Error message */
     test_redis_parse_rsp_success_case("+OK\r\n");  /* Error message without a space */
 


### PR DESCRIPTION
And add unit tests of redis messages being parsed successfully

Add testcase of error with no space

The test case was cherry-picked from https://github.com/twitter/twemproxy/pull/406

The alternate fix a74db76ce816caa14e8a85548f34088f9c594e6e was used - both do the same thing, not subtracting is personal preference

Amended to work with the updated test framework

The implementation/C unit test was amended to follow twemproxy's c style guide

Closes #404


Solution

Properly find the end of the line for a redis error when there's no space after the error type

Result

Redis errors that are just the error type will be processed by twemproxy correctly
