### PR TITLE
Fix processing of redis multibulk (nested array) responses (from eval, new commands, etc)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@
 	  Allow extra parameters for redis spop (charsyam)
 	  Update documentation and README (various)
 	  Fix memory leak bug for redis mset (deep011)
+	  Support arbitrarily deep nested redis multi-bulk
+	  responses (nested arrays) (qingping209, tyson)
 
  2015-22-06  Manju Rajashekhar  <manj@cs.stanford.edu>
     * twemproxy: version 0.4.1 release

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -255,6 +255,8 @@ done:
     msg->narg_end = NULL;
     msg->narg = 0;
     msg->rnarg = 0;
+    memset(msg->stack, 0, sizeof(msg->stack));
+    msg->nested_depth = 0;
     msg->rlen = 0;
     msg->integer = 0;
 

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -255,9 +255,11 @@ done:
     msg->narg_end = NULL;
     msg->narg = 0;
     msg->rnarg = 0;
-    memset(msg->stack, 0, sizeof(msg->stack));
-    msg->nested_depth = 0;
     msg->rlen = 0;
+    /*
+     * This is used for both parsing redis responses
+     * and as a counter for coalescing responses such as DEL
+     */
     msg->integer = 0;
 
     msg->err = 0;

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -20,6 +20,8 @@
 
 #include <nc_core.h>
 
+#define MAXDEPTH 4
+
 typedef void (*msg_parse_t)(struct msg *);
 typedef rstatus_t (*msg_add_auth_t)(struct context *ctx, struct conn *c_conn, struct conn *s_conn);
 typedef rstatus_t (*msg_fragment_t)(struct msg *, uint32_t, struct msg_tqh *);
@@ -275,6 +277,8 @@ struct msg {
     uint8_t              *narg_end;       /* narg end (redis) */
     uint32_t             narg;            /* # arguments (redis) */
     uint32_t             rnarg;           /* running # arg used by parsing fsa (redis) */
+    uint32_t             stack[MAXDEPTH]; /* stack to save rnarg of nesting multibulks */
+    uint8_t              nested_depth;    /* the depth of the current nested multibulk */
     uint32_t             rlen;            /* running length in parsing fsa (redis) */
     uint32_t             integer;         /* integer reply value (redis) */
 

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -275,12 +275,11 @@ struct msg {
 
     uint8_t              *narg_start;     /* narg start (redis) */
     uint8_t              *narg_end;       /* narg end (redis) */
-    uint32_t             narg;            /* # arguments (redis) */
+    uint32_t             narg;            /* # arguments (redis, memcache) */
     uint32_t             rnarg;           /* running # arg used by parsing fsa (redis) */
-    uint32_t             stack[MAXDEPTH]; /* stack to save rnarg of nesting multibulks */
-    uint8_t              nested_depth;    /* the depth of the current nested multibulk */
     uint32_t             rlen;            /* running length in parsing fsa (redis) */
     uint32_t             integer;         /* integer reply value (redis) */
+    uint32_t             is_top_level;    /* is this top level (redis) */
 
     struct msg           *frag_owner;     /* owner of fragment message */
     uint32_t             nfrag;           /* # fragment */

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1943,6 +1943,7 @@ redis_parse_rsp(struct msg *r)
     struct mbuf *b;
     uint8_t *p, *m;
     uint8_t ch;
+    int depth;
 
     enum {
         SW_START,
@@ -2161,8 +2162,9 @@ redis_parse_rsp(struct msg *r)
 
         case SW_SIMPLE:
             if (ch == CR) {
-              state = SW_MULTIBULK_ARGN_LF;
-              r->rnarg--;
+                r->rnarg--;
+                r->stack[r->nested_depth-1]--;
+                state = SW_MULTIBULK_ARGN_LF;
             }
             break;
 
@@ -2279,8 +2281,18 @@ redis_parse_rsp(struct msg *r)
                 /* rsp_start <- p */
                 r->narg_start = p;
                 r->rnarg = 0;
+                r->nested_depth++;
+
+                if (r->nested_depth > MAXDEPTH) {
+                    log_debug(LOG_ERR, "only support %d levels of multibulk", MAXDEPTH);
+                    goto error;
+                }
             } else if (ch == '-') {
-                state = SW_RUNTO_CRLF;
+                p = p-1;
+                r->token = NULL;
+                r->rnarg = 1;
+                r->stack[r->nested_depth-1] = r->rnarg;
+                state = SW_MULTIBULK_ARGN_LEN;
             } else if (isdigit(ch)) {
                 r->rnarg = r->rnarg * 10 + (uint32_t)(ch - '0');
             } else if (ch == CR) {
@@ -2291,6 +2303,8 @@ redis_parse_rsp(struct msg *r)
                 r->narg = r->rnarg;
                 r->narg_end = p;
                 r->token = NULL;
+
+                r->stack[r->nested_depth-1] = r->narg;
                 state = SW_MULTIBULK_NARG_LF;
             } else {
                 goto error;
@@ -2303,7 +2317,17 @@ redis_parse_rsp(struct msg *r)
             case LF:
                 if (r->rnarg == 0) {
                     /* response is '*0\r\n' */
-                    goto done;
+                    if (r->nested_depth == 1) {
+                        goto done;
+                    } else {
+                        log_debug(LOG_VVVERB,
+                            "multibulk support@end of a nested empty bulk %d %d %s",
+                            r->nested_depth, r->stack[r->nested_depth-1], p);
+
+                        p = p - 1;
+                        state = SW_MULTIBULK_ARGN_LF;
+                        break;
+                    }
                 }
 
                 state = SW_MULTIBULK_ARGN_LEN;
@@ -2377,6 +2401,7 @@ redis_parse_rsp(struct msg *r)
                 }
                 r->rnarg--;
                 r->token = NULL;
+                r->stack[r->nested_depth-1]--;
             } else {
                 goto error;
             }
@@ -2418,7 +2443,23 @@ redis_parse_rsp(struct msg *r)
         case SW_MULTIBULK_ARGN_LF:
             switch (ch) {
             case LF:
-                if (r->rnarg == 0) {
+                log_debug(LOG_VVVERB,
+                    "multibulk support@the end of the bulk: %d %d %s",
+                    r->nested_depth, r->stack[r->nested_depth-1], p);
+
+                depth = r->nested_depth;
+                while (depth > 1 && r->stack[depth-1] == 0) {
+                    depth--;
+                    r->stack[depth-1]--;
+                    r->nested_depth = depth;
+                    r->rnarg = r->stack[depth-1];
+
+                    log_debug(LOG_VVVERB,
+                        "multibulk support@the end of a nested multibulk: %d %d %s",
+                        r->nested_depth, r->stack[r->nested_depth-1], p);
+                }
+
+                if (r->stack[0] == 0) {
                     goto done;
                 }
 

--- a/src/test_all.c
+++ b/src/test_all.c
@@ -133,6 +133,18 @@ static void test_redis_parse_rsp_success(void) {
     test_redis_parse_rsp_success_case("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n");  /* array with 2 bulk strings */
     test_redis_parse_rsp_success_case("*3\r\n:1\r\n:2\r\n:3\r\n");  /* array with 3 integers */
     test_redis_parse_rsp_success_case("*-1\r\n");  /* null array for BLPOP */
+    /*
+     * Test support for parsing arrays of arrays.
+     * They can be returned by COMMAND, EVAL, etc.
+     */
+    test_redis_parse_rsp_success_case("*2\r\n"
+            "*3\r\n"
+            ":1\r\n"
+            ":2\r\n"
+            ":3\r\n"
+            "*2\r\n"
+            "+Foo\r\n"
+            "-Bar\r\n");  /* array of 2 arrays */
 }
 
 static void test_memcache_parse_rsp_success_case(char* data, int expected) {

--- a/tests/test_redis/test_basic.py
+++ b/tests/test_redis/test_basic.py
@@ -140,6 +140,9 @@ def test_issue_323():
     c = getconn()
     assert_equal([1, b'OK'], c.eval("return {1, redis.call('set', 'x', '1')}", 1, 'tmp'))
 
+    # Test processing deeply nested multibulk responses
+    assert_equal([[[[[[[[[[[[[[[[[[[[b'value']]]]]]]]]]]]]]]]]]], b'other'], c.eval("return {{{{{{{{{{{{{{{{{{{{'value'}}}}}}}}}}}}}}}}}}}, 'other'}", 1, 'tmp'))
+
 def setup_and_wait():
     time.sleep(60*60)
 


### PR DESCRIPTION
Problem

Redis hangs or misbehaves when processing multibulk redis responses (nested arrays)


Solution

Keep track of how many more elements need to be parsed when parsing the redis response,
as well as whether the top-level value is a multi-bulk response

Continue to properly count the number of top level array elements for request types that can be fragmented such as multi-gets

Result

twemproxy will now be able to proxy results of `eval` and other commands when they return nested arrays
(this will help in implementing `command` and `georadiuswithcoord`. commands in the future)


This is an amended version of https://github.com/twitter/twemproxy/pull/565 