### PR TITLE
Fix a crash seen when logging redis `COMMAND` in recent patches

### DIFF
--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -33,14 +33,14 @@ req_get(struct conn *conn)
 }
 
 static void
-req_log(struct msg *req)
+req_log(const struct msg *req)
 {
     struct msg *rsp;           /* peer message (response) */
     int64_t req_time;          /* time cost for this request */
-    char *peer_str;            /* peer client ip:port */
+    const char *peer_str;      /* peer client ip:port */
     uint32_t req_len, rsp_len; /* request and response length */
-    struct string *req_type;   /* request type string */
-    struct keypos *kpos;
+    const struct string *req_type; /* request type string */
+    const struct keypos *kpos;
 
     if (log_loggable(LOG_NOTICE) == 0) {
         return;
@@ -75,9 +75,6 @@ req_log(struct msg *req)
     }
 
     kpos = array_get(req->keys, 0);
-    if (kpos->end != NULL) {
-        *(kpos->end) = '\0';
-    }
 
     /*
      * FIXME: add backend addr here
@@ -90,10 +87,11 @@ req_log(struct msg *req)
 
     log_debug(LOG_NOTICE, "req %"PRIu64" done on c %d req_time %"PRIi64".%03"PRIi64
               " msec type %.*s narg %"PRIu32" req_len %"PRIu32" rsp_len %"PRIu32
-              " key0 '%s' peer '%s' done %d error %d",
+              " key0 '%.*s' peer '%s' done %d error %d",
               req->id, req->owner->sd, req_time / 1000, req_time % 1000,
               req_type->len, req_type->data, req->narg, req_len, rsp_len,
-              kpos->start, peer_str, req->done, req->error);
+              (int)(kpos->end ? kpos->end - kpos->start : 0), kpos->start,
+              peer_str, req->done, req->error);
 }
 
 void


### PR DESCRIPTION
The recent patches add support for a placeholder key, which is actually
a constant string in memory.

The logging helper method should not be mutating the data it's logging.

Solution:

Specify the length of the string to log instead of introducing a null
byte.
