### PR TITLE
Add const value qualifiers for C functions where applicable

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -30,7 +30,7 @@ RUN pip3.6 install nose && \
 # RUN yum install -y redis redis-sentinel
 
 ARG REDIS_VER=3.2.11
-RUN wget https://github.com/antirez/redis/archive/$REDIS_VER.tar.gz && \
+RUN wget https://github.com/redis/redis/archive/$REDIS_VER.tar.gz && \
 	tar zxvf $REDIS_VER.tar.gz && \
 	pushd redis-$REDIS_VER && \
 		make install && \

--- a/src/hashkit/nc_fnv.c
+++ b/src/hashkit/nc_fnv.c
@@ -17,10 +17,10 @@
 
 #include <nc_core.h>
 
-static uint64_t FNV_64_INIT = UINT64_C(0xcbf29ce484222325);
-static uint64_t FNV_64_PRIME = UINT64_C(0x100000001b3);
-static uint32_t FNV_32_INIT = 2166136261UL;
-static uint32_t FNV_32_PRIME = 16777619;
+static const uint64_t FNV_64_INIT = UINT64_C(0xcbf29ce484222325);
+static const uint64_t FNV_64_PRIME = UINT64_C(0x100000001b3);
+static const uint32_t FNV_32_INIT = 2166136261UL;
+static const uint32_t FNV_32_PRIME = 16777619;
 
 uint32_t
 hash_fnv1_64(const char *key, size_t key_length)

--- a/src/hashkit/nc_hashkit.h
+++ b/src/hashkit/nc_hashkit.h
@@ -69,11 +69,11 @@ uint32_t hash_jenkins(const char *key, size_t length);
 uint32_t hash_murmur(const char *key, size_t length);
 
 rstatus_t ketama_update(struct server_pool *pool);
-uint32_t ketama_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
+uint32_t ketama_dispatch(const struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
 rstatus_t modula_update(struct server_pool *pool);
-uint32_t modula_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
+uint32_t modula_dispatch(const struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
 rstatus_t random_update(struct server_pool *pool);
-uint32_t random_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
+uint32_t random_dispatch(const struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
 uint32_t ketama_hash(const char *key, size_t key_length, uint32_t alignment);
 
 #endif

--- a/src/hashkit/nc_ketama.c
+++ b/src/hashkit/nc_ketama.c
@@ -219,9 +219,9 @@ ketama_update(struct server_pool *pool)
 }
 
 uint32_t
-ketama_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash)
+ketama_dispatch(const struct continuum *continuum, uint32_t ncontinuum, uint32_t hash)
 {
-    struct continuum *begin, *end, *left, *right, *middle;
+    const struct continuum *begin, *end, *left, *right, *middle;
 
     ASSERT(continuum != NULL);
     ASSERT(ncontinuum != 0);

--- a/src/hashkit/nc_md5.c
+++ b/src/hashkit/nc_md5.c
@@ -85,10 +85,10 @@ typedef struct {
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
-static void *
-body(MD5_CTX *ctx, void *data, unsigned long size)
+static const void *
+body(MD5_CTX *ctx, const void *data, unsigned long size)
 {
-    unsigned char *ptr;
+    const unsigned char *ptr;
     MD5_u32plus a, b, c, d;
     MD5_u32plus saved_a, saved_b, saved_c, saved_d;
 
@@ -206,7 +206,7 @@ MD5_Init(MD5_CTX *ctx)
 }
 
 void
-MD5_Update(MD5_CTX *ctx, void *data, unsigned long size)
+MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size)
 {
     MD5_u32plus saved_lo;
     unsigned long used, free;
@@ -228,7 +228,7 @@ MD5_Update(MD5_CTX *ctx, void *data, unsigned long size)
         }
 
         memcpy(&ctx->buffer[used], data, free);
-        data = (unsigned char *)data + free;
+        data = (const unsigned char *)data + free;
         size -= free;
         body(ctx, ctx->buffer, 64);
     }
@@ -298,7 +298,7 @@ MD5_Final(unsigned char *result, MD5_CTX *ctx)
  * result must be == 16
  */
 void
-md5_signature(unsigned char *key, unsigned long length, unsigned char *result)
+md5_signature(const unsigned char *key, unsigned long length, unsigned char *result)
 {
     MD5_CTX my_md5;
 
@@ -312,7 +312,7 @@ hash_md5(const char *key, size_t key_length)
 {
     unsigned char results[16];
 
-    md5_signature((unsigned char*)key, (unsigned long)key_length, results);
+    md5_signature((const unsigned char*)key, (unsigned long)key_length, results);
 
     return ((uint32_t) (results[3] & 0xFF) << 24) |
            ((uint32_t) (results[2] & 0xFF) << 16) |

--- a/src/hashkit/nc_modula.c
+++ b/src/hashkit/nc_modula.c
@@ -143,9 +143,9 @@ modula_update(struct server_pool *pool)
 }
 
 uint32_t
-modula_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash)
+modula_dispatch(const struct continuum *continuum, uint32_t ncontinuum, uint32_t hash)
 {
-    struct continuum *c;
+    const struct continuum *c;
 
     ASSERT(continuum != NULL);
     ASSERT(ncontinuum != 0);

--- a/src/hashkit/nc_random.c
+++ b/src/hashkit/nc_random.c
@@ -133,9 +133,9 @@ random_update(struct server_pool *pool)
 }
 
 uint32_t
-random_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash)
+random_dispatch(const struct continuum *continuum, uint32_t ncontinuum, uint32_t hash)
 {
-    struct continuum *c;
+    const struct continuum *c;
 
     ASSERT(continuum != NULL);
     ASSERT(ncontinuum != 0);

--- a/src/nc.c
+++ b/src/nc.c
@@ -51,7 +51,7 @@ static int test_conf;
 static int daemonize;
 static int describe_stats;
 
-static struct option long_options[] = {
+static const struct option long_options[] = {
     { "help",           no_argument,        NULL,   'h' },
     { "version",        no_argument,        NULL,   'V' },
     { "test-conf",      no_argument,        NULL,   't' },
@@ -68,7 +68,7 @@ static struct option long_options[] = {
     { NULL,             0,                  NULL,    0  }
 };
 
-static char short_options[] = "hVtdDv:o:c:s:i:a:p:m:";
+static const char short_options[] = "hVtdDv:o:c:s:i:a:p:m:";
 
 static rstatus_t
 nc_daemonize(int dump_core)
@@ -173,7 +173,7 @@ nc_daemonize(int dump_core)
 }
 
 static void
-nc_print_run(struct instance *nci)
+nc_print_run(const struct instance *nci)
 {
     int status;
     struct utsname name;
@@ -446,7 +446,7 @@ nc_get_options(int argc, char **argv, struct instance *nci)
  * returns false
  */
 static bool
-nc_test_conf(struct instance *nci)
+nc_test_conf(const struct instance *nci)
 {
     struct conf *cf;
 

--- a/src/nc_array.c
+++ b/src/nc_array.c
@@ -79,9 +79,9 @@ array_deinit(struct array *a)
 }
 
 uint32_t
-array_idx(struct array *a, void *elem)
+array_idx(const struct array *a, const void *elem)
 {
-    uint8_t *p, *q;
+    const uint8_t *p, *q;
     uint32_t off, idx;
 
     ASSERT(elem >= a->elem);
@@ -136,7 +136,7 @@ array_pop(struct array *a)
 }
 
 void *
-array_get(struct array *a, uint32_t idx)
+array_get(const struct array *a, uint32_t idx)
 {
     void *elem;
 
@@ -149,7 +149,7 @@ array_get(struct array *a, uint32_t idx)
 }
 
 void *
-array_top(struct array *a)
+array_top(const struct array *a)
 {
     ASSERT(a->nelem != 0);
 
@@ -183,7 +183,7 @@ array_sort(struct array *a, array_compare_t compare)
  * success. On failure short-circuits and returns the error status.
  */
 rstatus_t
-array_each(struct array *a, array_each_t func, void *data)
+array_each(const struct array *a, array_each_t func, void *data)
 {
     uint32_t i, nelem;
 

--- a/src/nc_array.h
+++ b/src/nc_array.h
@@ -61,13 +61,13 @@ void array_destroy(struct array *a);
 rstatus_t array_init(struct array *a, uint32_t n, size_t size);
 void array_deinit(struct array *a);
 
-uint32_t array_idx(struct array *a, void *elem);
+uint32_t array_idx(const struct array *a, const void *elem);
 void *array_push(struct array *a);
 void *array_pop(struct array *a);
-void *array_get(struct array *a, uint32_t idx);
-void *array_top(struct array *a);
+void *array_get(const struct array *a, uint32_t idx);
+void *array_top(const struct array *a);
 void array_swap(struct array *a, struct array *b);
 void array_sort(struct array *a, array_compare_t compare);
-rstatus_t array_each(struct array *a, array_each_t func, void *data);
+rstatus_t array_each(const struct array *a, array_each_t func, void *data);
 
 #endif

--- a/src/nc_client.c
+++ b/src/nc_client.c
@@ -66,7 +66,7 @@ client_unref(struct conn *conn)
 }
 
 bool
-client_active(struct conn *conn)
+client_active(const struct conn *conn)
 {
     ASSERT(conn->client && !conn->proxy);
 

--- a/src/nc_client.h
+++ b/src/nc_client.h
@@ -20,7 +20,7 @@
 
 #include <nc_core.h>
 
-bool client_active(struct conn *conn);
+bool client_active(const struct conn *conn);
 void client_ref(struct conn *conn, void *owner);
 void client_unref(struct conn *conn);
 void client_close(struct context *ctx, struct conn *conn);

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -21,27 +21,27 @@
 #include <proto/nc_proto.h>
 
 #define DEFINE_ACTION(_hash, _name) string(#_name),
-static struct string hash_strings[] = {
+static const struct string hash_strings[] = {
     HASH_CODEC( DEFINE_ACTION )
     null_string
 };
 #undef DEFINE_ACTION
 
 #define DEFINE_ACTION(_hash, _name) hash_##_name,
-static hash_t hash_algos[] = {
+static const hash_t hash_algos[] = {
     HASH_CODEC( DEFINE_ACTION )
     NULL
 };
 #undef DEFINE_ACTION
 
 #define DEFINE_ACTION(_dist, _name) string(#_name),
-static struct string dist_strings[] = {
+static const struct string dist_strings[] = {
     DIST_CODEC( DEFINE_ACTION )
     null_string
 };
 #undef DEFINE_ACTION
 
-static struct command conf_commands[] = {
+static const struct command conf_commands[] = {
     { string("listen"),
       conf_set_listen,
       offsetof(struct conf_pool, listen) },
@@ -497,7 +497,7 @@ conf_pop_scalar(struct conf *cf)
 static rstatus_t
 conf_handler(struct conf *cf, void *data)
 {
-    struct command *cmd;
+    const struct command *cmd;
     struct string *key, *value;
     uint32_t narg;
 
@@ -1415,7 +1415,7 @@ conf_destroy(struct conf *cf)
 }
 
 char *
-conf_set_string(struct conf *cf, struct command *cmd, void *conf)
+conf_set_string(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
     uint8_t *p;
@@ -1439,7 +1439,7 @@ conf_set_string(struct conf *cf, struct command *cmd, void *conf)
 }
 
 char *
-conf_set_listen(struct conf *cf, struct command *cmd, void *conf)
+conf_set_listen(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
     struct string *value;
@@ -1528,7 +1528,7 @@ conf_set_listen(struct conf *cf, struct command *cmd, void *conf)
 }
 
 char *
-conf_add_server(struct conf *cf, struct command *cmd, void *conf)
+conf_add_server(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
     struct array *a;
@@ -1668,7 +1668,7 @@ conf_add_server(struct conf *cf, struct command *cmd, void *conf)
 }
 
 char *
-conf_set_num(struct conf *cf, struct command *cmd, void *conf)
+conf_set_num(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     int num, *np;
@@ -1694,7 +1694,7 @@ conf_set_num(struct conf *cf, struct command *cmd, void *conf)
 }
 
 char *
-conf_set_bool(struct conf *cf, struct command *cmd, void *conf)
+conf_set_bool(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     int *bp;
@@ -1723,11 +1723,12 @@ conf_set_bool(struct conf *cf, struct command *cmd, void *conf)
 }
 
 char *
-conf_set_hash(struct conf *cf, struct command *cmd, void *conf)
+conf_set_hash(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     hash_type_t *hp;
-    struct string *value, *hash;
+    struct string *value;
+    const struct string *hash;
 
     p = conf;
     hp = (hash_type_t *)(p + cmd->offset);
@@ -1752,11 +1753,12 @@ conf_set_hash(struct conf *cf, struct command *cmd, void *conf)
 }
 
 char *
-conf_set_distribution(struct conf *cf, struct command *cmd, void *conf)
+conf_set_distribution(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     dist_type_t *dp;
-    struct string *value, *dist;
+    struct string *value;
+    const struct string *dist;
 
     p = conf;
     dp = (dist_type_t *)(p + cmd->offset);
@@ -1781,7 +1783,7 @@ conf_set_distribution(struct conf *cf, struct command *cmd, void *conf)
 }
 
 char *
-conf_set_hashtag(struct conf *cf, struct command *cmd, void *conf)
+conf_set_hashtag(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
     uint8_t *p;

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -515,7 +515,7 @@ conf_handler(struct conf *cf, void *data)
               value->len, value->data);
 
     for (cmd = conf_commands; cmd->name.len != 0; cmd++) {
-        char *rv;
+        const char *rv;
 
         if (string_compare(key, &cmd->name) != 0) {
             continue;
@@ -1414,7 +1414,7 @@ conf_destroy(struct conf *cf)
     nc_free(cf);
 }
 
-char *
+const char *
 conf_set_string(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
@@ -1438,7 +1438,7 @@ conf_set_string(struct conf *cf, const struct command *cmd, void *conf)
     return CONF_OK;
 }
 
-char *
+const char *
 conf_set_listen(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
@@ -1527,7 +1527,7 @@ conf_set_listen(struct conf *cf, const struct command *cmd, void *conf)
     return CONF_OK;
 }
 
-char *
+const char *
 conf_add_server(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
@@ -1537,7 +1537,7 @@ conf_add_server(struct conf *cf, const struct command *cmd, void *conf)
     uint8_t *p, *q, *start;
     uint8_t *pname, *addr, *port, *weight, *name;
     uint32_t k, delimlen, pnamelen, addrlen, portlen, weightlen, namelen;
-    char delim[] = " ::";
+    const char *const delim = " ::";
 
     p = conf;
     a = (struct array *)(p + cmd->offset);
@@ -1667,7 +1667,7 @@ conf_add_server(struct conf *cf, const struct command *cmd, void *conf)
     return CONF_OK;
 }
 
-char *
+const char *
 conf_set_num(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
@@ -1693,7 +1693,7 @@ conf_set_num(struct conf *cf, const struct command *cmd, void *conf)
     return CONF_OK;
 }
 
-char *
+const char *
 conf_set_bool(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
@@ -1722,7 +1722,7 @@ conf_set_bool(struct conf *cf, const struct command *cmd, void *conf)
     return CONF_OK;
 }
 
-char *
+const char *
 conf_set_hash(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
@@ -1752,7 +1752,7 @@ conf_set_hash(struct conf *cf, const struct command *cmd, void *conf)
     return "is not a valid hash";
 }
 
-char *
+const char *
 conf_set_distribution(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
@@ -1782,7 +1782,7 @@ conf_set_distribution(struct conf *cf, const struct command *cmd, void *conf)
     return "is not a valid distribution";
 }
 
-char *
+const char *
 conf_set_hashtag(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -750,7 +750,7 @@ conf_parse(struct conf *cf)
 }
 
 static struct conf *
-conf_open(char *filename)
+conf_open(const char *filename)
 {
     rstatus_t status;
     struct conf *cf;
@@ -1354,7 +1354,7 @@ conf_post_validate(struct conf *cf)
 }
 
 struct conf *
-conf_create(char *filename)
+conf_create(const char *filename)
 {
     rstatus_t status;
     struct conf *cf;

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -315,7 +315,7 @@ conf_pool_each_transform(void *elem, void *data)
 }
 
 static void
-conf_dump(struct conf *cf)
+conf_dump(const struct conf *cf)
 {
     uint32_t i, j, npool, nserver;
     struct conf_pool *cp;

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -113,6 +113,9 @@ static const struct command conf_commands[] = {
     null_command
 };
 
+static const struct string true_str = string("true");
+static const struct string false_str = string("false");
+
 static void
 conf_server_init(struct conf_server *cs)
 {
@@ -175,7 +178,7 @@ conf_server_each_transform(void *elem, void *data)
 }
 
 static rstatus_t
-conf_pool_init(struct conf_pool *cp, struct string *name)
+conf_pool_init(struct conf_pool *cp, const struct string *name)
 {
     rstatus_t status;
 
@@ -1419,7 +1422,8 @@ conf_set_string(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
     uint8_t *p;
-    struct string *field, *value;
+    struct string *field;
+    const struct string *value;
 
     p = conf;
     field = (struct string *)(p + cmd->offset);
@@ -1672,7 +1676,7 @@ conf_set_num(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     int num, *np;
-    struct string *value;
+    const struct string *value;
 
     p = conf;
     np = (int *)(p + cmd->offset);
@@ -1698,7 +1702,7 @@ conf_set_bool(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     int *bp;
-    struct string *value, true_str, false_str;
+    const struct string *value;
 
     p = conf;
     bp = (int *)(p + cmd->offset);
@@ -1708,8 +1712,6 @@ conf_set_bool(struct conf *cf, const struct command *cmd, void *conf)
     }
 
     value = array_top(&cf->arg);
-    string_set_text(&true_str, "true");
-    string_set_text(&false_str, "false");
 
     if (string_compare(value, &true_str) == 0) {
         *bp = 1;
@@ -1727,8 +1729,7 @@ conf_set_hash(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     hash_type_t *hp;
-    struct string *value;
-    const struct string *hash;
+    const struct string *value, *hash;
 
     p = conf;
     hp = (hash_type_t *)(p + cmd->offset);
@@ -1757,8 +1758,7 @@ conf_set_distribution(struct conf *cf, const struct command *cmd, void *conf)
 {
     uint8_t *p;
     dist_type_t *dp;
-    struct string *value;
-    const struct string *dist;
+    const struct string *value, *dist;
 
     p = conf;
     dp = (dist_type_t *)(p + cmd->offset);
@@ -1787,7 +1787,8 @@ conf_set_hashtag(struct conf *cf, const struct command *cmd, void *conf)
 {
     rstatus_t status;
     uint8_t *p;
-    struct string *field, *value;
+    struct string *field;
+    const struct string *value;
 
     p = conf;
     field = (struct string *)(p + cmd->offset);

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -117,20 +117,20 @@ struct conf {
 
 struct command {
     struct string name;
-    char          *(*set)(struct conf *cf, const struct command *cmd, void *data);
+    const char    *(*set)(struct conf *cf, const struct command *cmd, void *data);
     int           offset;
 };
 
 #define null_command { null_string, NULL, 0 }
 
-char *conf_set_string(struct conf *cf, const struct command *cmd, void *conf);
-char *conf_set_listen(struct conf *cf, const struct command *cmd, void *conf);
-char *conf_add_server(struct conf *cf, const struct command *cmd, void *conf);
-char *conf_set_num(struct conf *cf, const struct command *cmd, void *conf);
-char *conf_set_bool(struct conf *cf, const struct command *cmd, void *conf);
-char *conf_set_hash(struct conf *cf, const struct command *cmd, void *conf);
-char *conf_set_distribution(struct conf *cf, const struct command *cmd, void *conf);
-char *conf_set_hashtag(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_set_string(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_set_listen(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_add_server(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_set_num(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_set_bool(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_set_hash(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_set_distribution(struct conf *cf, const struct command *cmd, void *conf);
+const char *conf_set_hashtag(struct conf *cf, const struct command *cmd, void *conf);
 
 rstatus_t conf_server_each_transform(void *elem, void *data);
 rstatus_t conf_pool_each_transform(void *elem, void *data);

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -98,7 +98,7 @@ struct conf_pool {
 };
 
 struct conf {
-    char          *fname;           /* file name (ref in argv[]) */
+    const char    *fname;           /* file name (ref in argv[]) */
     FILE          *fh;              /* file handle */
     struct array  arg;              /* string[] (parsed {key, value} pairs) */
     struct array  pool;             /* conf_pool[] (parsed pools) */
@@ -135,7 +135,7 @@ char *conf_set_hashtag(struct conf *cf, struct command *cmd, void *conf);
 rstatus_t conf_server_each_transform(void *elem, void *data);
 rstatus_t conf_pool_each_transform(void *elem, void *data);
 
-struct conf *conf_create(char *filename);
+struct conf *conf_create(const char *filename);
 void conf_destroy(struct conf *cf);
 
 #endif

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -117,20 +117,20 @@ struct conf {
 
 struct command {
     struct string name;
-    char          *(*set)(struct conf *cf, struct command *cmd, void *data);
+    char          *(*set)(struct conf *cf, const struct command *cmd, void *data);
     int           offset;
 };
 
 #define null_command { null_string, NULL, 0 }
 
-char *conf_set_string(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_listen(struct conf *cf, struct command *cmd, void *conf);
-char *conf_add_server(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_num(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_bool(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_hash(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_distribution(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_hashtag(struct conf *cf, struct command *cmd, void *conf);
+char *conf_set_string(struct conf *cf, const struct command *cmd, void *conf);
+char *conf_set_listen(struct conf *cf, const struct command *cmd, void *conf);
+char *conf_add_server(struct conf *cf, const struct command *cmd, void *conf);
+char *conf_set_num(struct conf *cf, const struct command *cmd, void *conf);
+char *conf_set_bool(struct conf *cf, const struct command *cmd, void *conf);
+char *conf_set_hash(struct conf *cf, const struct command *cmd, void *conf);
+char *conf_set_distribution(struct conf *cf, const struct command *cmd, void *conf);
+char *conf_set_hashtag(struct conf *cf, const struct command *cmd, void *conf);
 
 rstatus_t conf_server_each_transform(void *elem, void *data);
 rstatus_t conf_pool_each_transform(void *elem, void *data);

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -91,7 +91,7 @@ static uint32_t ncurr_cconn;       /* current # client connections */
  * Return the context associated with this connection.
  */
 struct context *
-conn_to_ctx(struct conn *conn)
+conn_to_ctx(const struct conn *conn)
 {
     struct server_pool *pool;
 

--- a/src/nc_connection.c
+++ b/src/nc_connection.c
@@ -245,9 +245,8 @@ conn_get(void *owner, bool client, bool redis)
 }
 
 struct conn *
-conn_get_proxy(void *owner)
+conn_get_proxy(struct server_pool *pool)
 {
-    struct server_pool *pool = owner;
     struct conn *conn;
 
     conn = _conn_get();
@@ -278,7 +277,7 @@ conn_get_proxy(void *owner)
     conn->enqueue_outq = NULL;
     conn->dequeue_outq = NULL;
 
-    conn->ref(conn, owner);
+    conn->ref(conn, pool);
 
     log_debug(LOG_VVERB, "get conn %p proxy %d", conn, conn->proxy);
 
@@ -382,7 +381,7 @@ conn_recv(struct conn *conn, void *buf, size_t size)
 }
 
 ssize_t
-conn_sendv(struct conn *conn, struct array *sendv, size_t nsend)
+conn_sendv(struct conn *conn, const struct array *sendv, size_t nsend)
 {
     ssize_t n;
 
@@ -453,7 +452,7 @@ conn_ncurr_cconn(void)
  * authentication, otherwise return false
  */
 bool
-conn_authenticated(struct conn *conn)
+conn_authenticated(const struct conn *conn)
 {
     struct server_pool *pool;
 

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -93,7 +93,7 @@ struct conn {
 
 TAILQ_HEAD(conn_tqh, conn);
 
-struct context *conn_to_ctx(struct conn *conn);
+struct context *conn_to_ctx(const struct conn *conn);
 struct conn *conn_get(void *owner, bool client, bool redis);
 struct conn *conn_get_proxy(struct server_pool *pool);
 void conn_put(struct conn *conn);

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -29,7 +29,7 @@ typedef struct msg* (*conn_send_next_t)(struct context *, struct conn *);
 typedef void (*conn_send_done_t)(struct context *, struct conn *, struct msg *);
 
 typedef void (*conn_close_t)(struct context *, struct conn *);
-typedef bool (*conn_active_t)(struct conn *);
+typedef bool (*conn_active_t)(const struct conn *);
 
 typedef void (*conn_ref_t)(struct conn *, void *);
 typedef void (*conn_unref_t)(struct conn *);
@@ -95,15 +95,15 @@ TAILQ_HEAD(conn_tqh, conn);
 
 struct context *conn_to_ctx(struct conn *conn);
 struct conn *conn_get(void *owner, bool client, bool redis);
-struct conn *conn_get_proxy(void *owner);
+struct conn *conn_get_proxy(struct server_pool *pool);
 void conn_put(struct conn *conn);
 ssize_t conn_recv(struct conn *conn, void *buf, size_t size);
-ssize_t conn_sendv(struct conn *conn, struct array *sendv, size_t nsend);
+ssize_t conn_sendv(struct conn *conn, const struct array *sendv, size_t nsend);
 void conn_init(void);
 void conn_deinit(void);
 uint32_t conn_ncurr_conn(void);
 uint64_t conn_ntotal_conn(void);
 uint32_t conn_ncurr_cconn(void);
-bool conn_authenticated(struct conn *conn);
+bool conn_authenticated(const struct conn *conn);
 
 #endif

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -220,7 +220,8 @@ static void
 core_close(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
-    char type, *addrstr;
+    char type;
+    const char *addrstr;
 
     ASSERT(conn->sd > 0);
 

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -137,15 +137,15 @@ struct context {
 struct instance {
     struct context  *ctx;                        /* active context */
     int             log_level;                   /* log level */
-    char            *log_filename;               /* log filename */
-    char            *conf_filename;              /* configuration filename */
+    const char      *log_filename;               /* log filename */
+    const char      *conf_filename;              /* configuration filename */
     uint16_t        stats_port;                  /* stats monitoring port */
     int             stats_interval;              /* stats aggregation interval */
-    char            *stats_addr;                 /* stats monitoring addr */
+    const char      *stats_addr;                 /* stats monitoring addr */
     char            hostname[NC_MAXHOSTNAMELEN]; /* hostname */
     size_t          mbuf_chunk_size;             /* mbuf chunk size */
     pid_t           pid;                         /* process id */
-    char            *pid_filename;               /* pid filename */
+    const char      *pid_filename;               /* pid filename */
     unsigned        pidfile:1;                   /* pid file created? */
 };
 

--- a/src/nc_log.c
+++ b/src/nc_log.c
@@ -27,7 +27,7 @@
 static struct logger logger;
 
 int
-log_init(int level, char *name)
+log_init(int level, const char *name)
 {
     struct logger *l = &logger;
 
@@ -202,7 +202,7 @@ _log_stderr(const char *fmt, ...)
  * See -C option in man hexdump
  */
 void
-_log_hexdump(const char *file, int line, char *data, int datalen,
+_log_hexdump(const char *file, int line, const char *data, int datalen,
              const char *fmt, ...)
 {
     struct logger *l = &logger;
@@ -221,7 +221,7 @@ _log_hexdump(const char *file, int line, char *data, int datalen,
     size = 8 * LOG_MAX_LEN;   /* size of output buffer */
 
     while (datalen != 0 && (len < size - 1)) {
-        char *save, *str;
+        const char *save, *str;
         unsigned char c;
         int savelen;
 

--- a/src/nc_log.h
+++ b/src/nc_log.h
@@ -18,11 +18,13 @@
 #ifndef _NC_LOG_H_
 #define _NC_LOG_H_
 
+#include <nc_util.h>
+
 struct logger {
-    char *name;  /* log file name */
-    int  level;  /* log level */
-    int  fd;     /* log file descriptor */
-    int  nerror; /* # log error */
+    const char *name; /* log file name */
+    int  level;       /* log level */
+    int  fd;          /* log file descriptor */
+    int  nerror;      /* # log error */
 };
 
 #define LOG_EMERG   0   /* system in unusable */
@@ -115,18 +117,7 @@ struct logger {
 } while (0)
 
 
-#ifdef __GNUC__
-# define NC_GCC_VERSION (__GNUC__ * 1000 + __GNUC_MINOR__)
-#else
-# define NC_GCC_VERSION 0
-#endif
-#if NC_GCC_VERSION >= 2007
-#define NC_ATTRIBUTE_FORMAT(type, idx, first) __attribute__ ((format(type, idx, first)))
-#else
-#define NC_ATTRIBUTE_FORMAT(type, idx, first)
-#endif
-
-int log_init(int level, char *filename);
+int log_init(int level, const char *filename);
 void log_deinit(void);
 void log_level_up(void);
 void log_level_down(void);
@@ -138,6 +129,6 @@ void _log(const char *file, int line, int panic, const char *fmt, ...) NC_ATTRIB
 void _log_stderr(const char *fmt, ...) NC_ATTRIBUTE_FORMAT(printf, 1, 2);
 void _log_safe(const char *fmt, ...) NC_ATTRIBUTE_FORMAT(printf, 1, 2);
 void _log_stderr_safe(const char *fmt, ...) NC_ATTRIBUTE_FORMAT(printf, 1, 2);
-void _log_hexdump(const char *file, int line, char *data, int datalen, const char *fmt, ...);
+void _log_hexdump(const char *file, int line, const char *data, int datalen, const char *fmt, ...);
 
 #endif

--- a/src/nc_mbuf.c
+++ b/src/nc_mbuf.c
@@ -143,7 +143,7 @@ mbuf_rewind(struct mbuf *mbuf)
  * 2^32 bytes (4G).
  */
 uint32_t
-mbuf_length(struct mbuf *mbuf)
+mbuf_length(const struct mbuf *mbuf)
 {
     ASSERT(mbuf->last >= mbuf->pos);
 
@@ -155,7 +155,7 @@ mbuf_length(struct mbuf *mbuf)
  * contain more than 2^32 bytes (4G).
  */
 uint32_t
-mbuf_size(struct mbuf *mbuf)
+mbuf_size(const struct mbuf *mbuf)
 {
     ASSERT(mbuf->end >= mbuf->last);
 
@@ -203,7 +203,7 @@ mbuf_remove(struct mhdr *mhdr, struct mbuf *mbuf)
  * enough space for n bytes.
  */
 void
-mbuf_copy(struct mbuf *mbuf, uint8_t *pos, size_t n)
+mbuf_copy(struct mbuf *mbuf, const uint8_t *pos, size_t n)
 {
     if (n == 0) {
         return;
@@ -262,7 +262,7 @@ mbuf_split(struct mhdr *h, uint8_t *pos, mbuf_copy_t cb, void *cbarg)
 }
 
 void
-mbuf_init(struct instance *nci)
+mbuf_init(const struct instance *nci)
 {
     nfree_mbufq = 0;
     STAILQ_INIT(&free_mbufq);

--- a/src/nc_mbuf.h
+++ b/src/nc_mbuf.h
@@ -40,28 +40,28 @@ STAILQ_HEAD(mhdr, mbuf);
 #define MBUF_HSIZE      sizeof(struct mbuf)
 
 static inline bool
-mbuf_empty(struct mbuf *mbuf)
+mbuf_empty(const struct mbuf *mbuf)
 {
-    return mbuf->pos == mbuf->last ? true : false;
+    return mbuf->pos == mbuf->last;
 }
 
 static inline bool
-mbuf_full(struct mbuf *mbuf)
+mbuf_full(const struct mbuf *mbuf)
 {
-    return mbuf->last == mbuf->end ? true : false;
+    return mbuf->last == mbuf->end;
 }
 
-void mbuf_init(struct instance *nci);
+void mbuf_init(const struct instance *nci);
 void mbuf_deinit(void);
 struct mbuf *mbuf_get(void);
 void mbuf_put(struct mbuf *mbuf);
 void mbuf_rewind(struct mbuf *mbuf);
-uint32_t mbuf_length(struct mbuf *mbuf);
-uint32_t mbuf_size(struct mbuf *mbuf);
+uint32_t mbuf_length(const struct mbuf *mbuf);
+uint32_t mbuf_size(const struct mbuf *mbuf);
 size_t mbuf_data_size(void);
 void mbuf_insert(struct mhdr *mhdr, struct mbuf *mbuf);
 void mbuf_remove(struct mhdr *mhdr, struct mbuf *mbuf);
-void mbuf_copy(struct mbuf *mbuf, uint8_t *pos, size_t n);
+void mbuf_copy(struct mbuf *mbuf, const uint8_t *pos, size_t n);
 struct mbuf *mbuf_split(struct mhdr *h, uint8_t *pos, mbuf_copy_t cb, void *cbarg);
 
 #endif

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -458,7 +458,7 @@ msg_empty(struct msg *msg)
 }
 
 uint32_t
-msg_backend_idx(struct msg *msg, uint8_t *key, uint32_t keylen)
+msg_backend_idx(struct msg *msg, const uint8_t *key, uint32_t keylen)
 {
     struct conn *conn = msg->owner;
     struct server_pool *pool = conn->owner;
@@ -490,7 +490,7 @@ msg_ensure_mbuf(struct msg *msg, size_t len)
  * into mbuf
  */
 rstatus_t
-msg_append(struct msg *msg, uint8_t *pos, size_t n)
+msg_append(struct msg *msg, const uint8_t *pos, size_t n)
 {
     struct mbuf *mbuf;
 
@@ -514,7 +514,7 @@ msg_append(struct msg *msg, uint8_t *pos, size_t n)
  * into mbuf
  */
 rstatus_t
-msg_prepend(struct msg *msg, uint8_t *pos, size_t n)
+msg_prepend(struct msg *msg, const uint8_t *pos, size_t n)
 {
     struct mbuf *mbuf;
 

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -117,7 +117,7 @@ static struct rbtree tmo_rbt;    /* timeout rbtree */
 static struct rbnode tmo_rbs;    /* timeout rbtree sentinel */
 
 #define DEFINE_ACTION(_name) string(#_name),
-static struct string msg_type_strings[] = {
+static const struct string msg_type_strings[] = {
     MSG_TYPE_CODEC( DEFINE_ACTION )
     null_string
 };
@@ -396,9 +396,9 @@ msg_put(struct msg *msg)
 }
 
 void
-msg_dump(struct msg *msg, int level)
+msg_dump(const struct msg *msg, int level)
 {
-    struct mbuf *mbuf;
+    const struct mbuf *mbuf;
 
     if (log_loggable(level) == 0) {
         return;
@@ -445,14 +445,14 @@ msg_deinit(void)
     ASSERT(nfree_msgq == 0);
 }
 
-struct string *
+const struct string *
 msg_type_string(msg_type_t type)
 {
     return &msg_type_strings[type];
 }
 
 bool
-msg_empty(struct msg *msg)
+msg_empty(const struct msg *msg)
 {
     return msg->mlen == 0 ? true : false;
 }

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -454,7 +454,7 @@ msg_type_string(msg_type_t type)
 bool
 msg_empty(const struct msg *msg)
 {
-    return msg->mlen == 0 ? true : false;
+    return msg->mlen == 0;
 }
 
 uint32_t

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -458,7 +458,7 @@ msg_empty(struct msg *msg)
 }
 
 uint32_t
-msg_backend_idx(struct msg *msg, const uint8_t *key, uint32_t keylen)
+msg_backend_idx(const struct msg *msg, const uint8_t *key, uint32_t keylen)
 {
     struct conn *conn = msg->owner;
     struct server_pool *pool = conn->owner;

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -332,8 +332,8 @@ msg_get_error(bool redis, err_t err)
     struct msg *msg;
     struct mbuf *mbuf;
     int n;
-    char *errstr = err ? strerror(err) : "unknown";
-    char *protstr = redis ? "-ERR" : "SERVER_ERROR";
+    const char *errstr = err ? strerror(err) : "unknown";
+    const char *protstr = redis ? "-ERR" : "SERVER_ERROR";
 
     msg = _msg_get();
     if (msg == NULL) {

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -26,7 +26,7 @@ typedef rstatus_t (*msg_add_auth_t)(struct context *ctx, struct conn *c_conn, st
 typedef rstatus_t (*msg_fragment_t)(struct msg *, uint32_t, struct msg_tqh *);
 typedef void (*msg_coalesce_t)(struct msg *r);
 typedef rstatus_t (*msg_reply_t)(struct msg *r);
-typedef bool (*msg_failure_t)(struct msg *r);
+typedef bool (*msg_failure_t)(const struct msg *r);
 
 typedef enum msg_parse_result {
     MSG_PARSE_OK,                         /* parsing ok */
@@ -318,7 +318,7 @@ void msg_read_line(struct msg* msg, struct mbuf *line_buf, int line_num);
 rstatus_t msg_recv(struct context *ctx, struct conn *conn);
 rstatus_t msg_send(struct context *ctx, struct conn *conn);
 uint64_t msg_gen_frag_id(void);
-uint32_t msg_backend_idx(struct msg *msg, const uint8_t *key, uint32_t keylen);
+uint32_t msg_backend_idx(const struct msg *msg, const uint8_t *key, uint32_t keylen);
 struct mbuf *msg_ensure_mbuf(struct msg *msg, size_t len);
 rstatus_t msg_append(struct msg *msg, const uint8_t *pos, size_t n);
 rstatus_t msg_prepend(struct msg *msg, const uint8_t *pos, size_t n);
@@ -326,8 +326,8 @@ rstatus_t msg_prepend_format(struct msg *msg, const char *fmt, ...);
 
 struct msg *req_get(struct conn *conn);
 void req_put(struct msg *msg);
-bool req_done(struct conn *conn, struct msg *msg);
-bool req_error(struct conn *conn, struct msg *msg);
+bool req_done(const struct conn *conn, struct msg *msg);
+bool req_error(const struct conn *conn, struct msg *msg);
 void req_server_enqueue_imsgq(struct context *ctx, struct conn *conn, struct msg *msg);
 void req_server_enqueue_imsgq_head(struct context *ctx, struct conn *conn, struct msg *msg);
 void req_server_dequeue_imsgq(struct context *ctx, struct conn *conn, struct msg *msg);

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -228,8 +228,8 @@ typedef enum msg_type {
 #undef DEFINE_ACTION
 
 struct keypos {
-    uint8_t             *start;           /* key start pos */
-    uint8_t             *end;             /* key end pos */
+    uint8_t              *start;           /* key start pos */
+    uint8_t              *end;             /* key end pos */
 };
 
 /*
@@ -279,7 +279,7 @@ struct msg {
     uint32_t             rnarg;           /* running # arg used by parsing fsa (redis) */
     uint32_t             rlen;            /* running length in parsing fsa (redis) */
     uint32_t             integer;         /* integer reply value (redis) */
-    uint8_t             is_top_level;     /* is this top level (redis) */
+    uint8_t              is_top_level;     /* is this top level (redis) */
 
     struct msg           *frag_owner;     /* owner of fragment message */
     uint32_t             nfrag;           /* # fragment */
@@ -318,10 +318,10 @@ void msg_read_line(struct msg* msg, struct mbuf *line_buf, int line_num);
 rstatus_t msg_recv(struct context *ctx, struct conn *conn);
 rstatus_t msg_send(struct context *ctx, struct conn *conn);
 uint64_t msg_gen_frag_id(void);
-uint32_t msg_backend_idx(struct msg *msg, uint8_t *key, uint32_t keylen);
+uint32_t msg_backend_idx(struct msg *msg, const uint8_t *key, uint32_t keylen);
 struct mbuf *msg_ensure_mbuf(struct msg *msg, size_t len);
-rstatus_t msg_append(struct msg *msg, uint8_t *pos, size_t n);
-rstatus_t msg_prepend(struct msg *msg, uint8_t *pos, size_t n);
+rstatus_t msg_append(struct msg *msg, const uint8_t *pos, size_t n);
+rstatus_t msg_prepend(struct msg *msg, const uint8_t *pos, size_t n);
 rstatus_t msg_prepend_format(struct msg *msg, const char *fmt, ...);
 
 struct msg *req_get(struct conn *conn);

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -308,13 +308,12 @@ void msg_tmo_delete(struct msg *msg);
 
 void msg_init(void);
 void msg_deinit(void);
-struct string *msg_type_string(msg_type_t type);
+const struct string *msg_type_string(msg_type_t type);
 struct msg *msg_get(struct conn *conn, bool request, bool redis);
 void msg_put(struct msg *msg);
 struct msg *msg_get_error(bool redis, err_t err);
-void msg_dump(struct msg *msg, int level);
-bool msg_empty(struct msg *msg);
-void msg_read_line(struct msg* msg, struct mbuf *line_buf, int line_num);
+void msg_dump(const struct msg *msg, int level);
+bool msg_empty(const struct msg *msg);
 rstatus_t msg_recv(struct context *ctx, struct conn *conn);
 rstatus_t msg_send(struct context *ctx, struct conn *conn);
 uint64_t msg_gen_frag_id(void);

--- a/src/nc_rbtree.c
+++ b/src/nc_rbtree.c
@@ -38,7 +38,7 @@ rbtree_init(struct rbtree *tree, struct rbnode *node)
 }
 
 static struct rbnode *
-rbtree_node_min(struct rbnode *node, struct rbnode *sentinel)
+rbtree_node_min(struct rbnode *node, const struct rbnode *sentinel)
 {
     /* traverse left links */
 
@@ -50,10 +50,10 @@ rbtree_node_min(struct rbnode *node, struct rbnode *sentinel)
 }
 
 struct rbnode *
-rbtree_min(struct rbtree *tree)
+rbtree_min(const struct rbtree *tree)
 {
     struct rbnode *node = tree->root;
-    struct rbnode *sentinel = tree->sentinel;
+    const struct rbnode *sentinel = tree->sentinel;
 
     /* empty tree */
 

--- a/src/nc_rbtree.h
+++ b/src/nc_rbtree.h
@@ -40,7 +40,7 @@ struct rbtree {
 
 void rbtree_node_init(struct rbnode *node);
 void rbtree_init(struct rbtree *tree, struct rbnode *node);
-struct rbnode *rbtree_min(struct rbtree *tree);
+struct rbnode *rbtree_min(const struct rbtree *tree);
 void rbtree_insert(struct rbtree *tree, struct rbnode *node);
 void rbtree_delete(struct rbtree *tree, struct rbnode *node);
 

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -35,7 +35,7 @@ req_get(struct conn *conn)
 static void
 req_log(const struct msg *req)
 {
-    struct msg *rsp;           /* peer message (response) */
+    const struct msg *rsp;           /* peer message (response) */
     int64_t req_time;          /* time cost for this request */
     const char *peer_str;      /* peer client ip:port */
     uint32_t req_len, rsp_len; /* request and response length */
@@ -122,9 +122,11 @@ req_put(struct msg *msg)
  * A request is done, if we received response for the given request.
  * A request vector is done if we received responses for all its
  * fragments.
+ *
+ * msg->fdone is modified to cache whether this request was done.
  */
 bool
-req_done(struct conn *conn, struct msg *msg)
+req_done(const struct conn *conn, struct msg *msg)
 {
     struct msg *cmsg;        /* current message */
     uint64_t id;             /* fragment id */
@@ -215,7 +217,7 @@ req_done(struct conn *conn, struct msg *msg)
  * receiving response for any its fragments.
  */
 bool
-req_error(struct conn *conn, struct msg *msg)
+req_error(const struct conn *conn, struct msg *msg)
 {
     struct msg *cmsg; /* current message */
     uint64_t id;
@@ -470,7 +472,7 @@ req_make_reply(struct context *ctx, struct conn *conn, struct msg *req)
 }
 
 static bool
-req_filter(struct context *ctx, struct conn *conn, struct msg *msg)
+req_filter(struct conn *conn, struct msg *msg)
 {
     ASSERT(conn->client && !conn->proxy);
 
@@ -640,7 +642,7 @@ req_recv_done(struct context *ctx, struct conn *conn, struct msg *msg,
     /* enqueue next message (request), if any */
     conn->rmsg = nmsg;
 
-    if (req_filter(ctx, conn, msg)) {
+    if (req_filter(conn, msg)) {
         return;
     }
 

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -640,7 +640,7 @@ server_pool_hash(const struct server_pool *pool, const uint8_t *key, uint32_t ke
         return 0;
     }
 
-    return pool->key_hash((char *)key, keylen);
+    return pool->key_hash((const char *)key, keylen);
 }
 
 uint32_t
@@ -694,7 +694,7 @@ server_pool_idx(const struct server_pool *pool, const uint8_t *key, uint32_t key
 }
 
 static struct server *
-server_pool_server(struct server_pool *pool, uint8_t *key, uint32_t keylen)
+server_pool_server(struct server_pool *pool, const uint8_t *key, uint32_t keylen)
 {
     struct server *server;
     uint32_t idx;
@@ -709,7 +709,7 @@ server_pool_server(struct server_pool *pool, uint8_t *key, uint32_t keylen)
 }
 
 struct conn *
-server_pool_conn(struct context *ctx, struct server_pool *pool, uint8_t *key,
+server_pool_conn(struct context *ctx, struct server_pool *pool, const uint8_t *key,
                  uint32_t keylen)
 {
     rstatus_t status;

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -92,7 +92,7 @@ server_timeout(struct conn *conn)
 }
 
 bool
-server_active(struct conn *conn)
+server_active(const struct conn *conn)
 {
     ASSERT(!conn->client && !conn->proxy);
 

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -627,7 +627,7 @@ server_pool_update(struct server_pool *pool)
 }
 
 static uint32_t
-server_pool_hash(struct server_pool *pool, uint8_t *key, uint32_t keylen)
+server_pool_hash(const struct server_pool *pool, const uint8_t *key, uint32_t keylen)
 {
     ASSERT(array_n(&pool->server) != 0);
     ASSERT(key != NULL);
@@ -644,7 +644,7 @@ server_pool_hash(struct server_pool *pool, uint8_t *key, uint32_t keylen)
 }
 
 uint32_t
-server_pool_idx(struct server_pool *pool, uint8_t *key, uint32_t keylen)
+server_pool_idx(const struct server_pool *pool, const uint8_t *key, uint32_t keylen)
 {
     uint32_t hash, idx;
 
@@ -657,8 +657,8 @@ server_pool_idx(struct server_pool *pool, uint8_t *key, uint32_t keylen)
      * we use the full key
      */
     if (!string_empty(&pool->hash_tag)) {
-        struct string *tag = &pool->hash_tag;
-        uint8_t *tag_start, *tag_end;
+        const struct string *tag = &pool->hash_tag;
+        const uint8_t *tag_start, *tag_end;
 
         tag_start = nc_strchr(key, key + keylen, tag->data[0]);
         if (tag_start != NULL) {

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -126,7 +126,7 @@ struct server_pool {
 void server_ref(struct conn *conn, void *owner);
 void server_unref(struct conn *conn);
 int server_timeout(struct conn *conn);
-bool server_active(struct conn *conn);
+bool server_active(const struct conn *conn);
 rstatus_t server_init(struct array *server, struct array *conf_server, struct server_pool *sp);
 void server_deinit(struct array *server);
 struct conn *server_conn(struct server *server);

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -136,7 +136,7 @@ void server_connected(struct context *ctx, struct conn *conn);
 void server_ok(struct context *ctx, struct conn *conn);
 
 uint32_t server_pool_idx(const struct server_pool *pool, const uint8_t *key, uint32_t keylen);
-struct conn *server_pool_conn(struct context *ctx, struct server_pool *pool, uint8_t *key, uint32_t keylen);
+struct conn *server_pool_conn(struct context *ctx, struct server_pool *pool, const uint8_t *key, uint32_t keylen);
 rstatus_t server_pool_run(struct server_pool *pool);
 rstatus_t server_pool_preconnect(struct context *ctx);
 void server_pool_disconnect(struct context *ctx);

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -135,7 +135,7 @@ void server_close(struct context *ctx, struct conn *conn);
 void server_connected(struct context *ctx, struct conn *conn);
 void server_ok(struct context *ctx, struct conn *conn);
 
-uint32_t server_pool_idx(struct server_pool *pool, uint8_t *key, uint32_t keylen);
+uint32_t server_pool_idx(const struct server_pool *pool, const uint8_t *key, uint32_t keylen);
 struct conn *server_pool_conn(struct context *ctx, struct server_pool *pool, uint8_t *key, uint32_t keylen);
 rstatus_t server_pool_run(struct server_pool *pool);
 rstatus_t server_pool_preconnect(struct context *ctx);

--- a/src/nc_signal.c
+++ b/src/nc_signal.c
@@ -21,7 +21,7 @@
 #include <nc_core.h>
 #include <nc_signal.h>
 
-static struct signal signals[] = {
+static const struct signal signals[] = {
     { SIGUSR1, "SIGUSR1", 0,                 signal_handler },
     { SIGUSR2, "SIGUSR2", 0,                 signal_handler },
     { SIGTTIN, "SIGTTIN", 0,                 signal_handler },
@@ -36,7 +36,7 @@ static struct signal signals[] = {
 rstatus_t
 signal_init(void)
 {
-    struct signal *sig;
+    const struct signal *sig;
 
     for (sig = signals; sig->signo != 0; sig++) {
         rstatus_t status;
@@ -66,7 +66,7 @@ signal_deinit(void)
 void
 signal_handler(int signo)
 {
-    struct signal *sig;
+    const struct signal *sig;
     void (*action)(void);
     char *actionstr;
     bool done;

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -42,11 +42,11 @@ static struct stats_metric stats_server_codec[] = {
 #undef DEFINE_ACTION
 
 #define DEFINE_ACTION(_name, _type, _desc) { .name = #_name, .desc = _desc },
-static struct stats_desc stats_pool_desc[] = {
+static const struct stats_desc stats_pool_desc[] = {
     STATS_POOL_CODEC( DEFINE_ACTION )
 };
 
-static struct stats_desc stats_server_desc[] = {
+static const struct stats_desc stats_server_desc[] = {
     STATS_SERVER_CODEC( DEFINE_ACTION )
 };
 #undef DEFINE_ACTION

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -887,8 +887,8 @@ stats_stop_aggregator(struct stats *st)
 }
 
 struct stats *
-stats_create(uint16_t stats_port, char *stats_ip, int stats_interval,
-             char *source, struct array *server_pool)
+stats_create(uint16_t stats_port, const char *stats_ip, int stats_interval,
+             const char *source, struct array *server_pool)
 {
     rstatus_t status;
     struct stats *st;

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -188,7 +188,7 @@ stats_server_init(struct stats_server *sts, struct server *s)
 }
 
 static rstatus_t
-stats_server_map(struct array *stats_server, struct array *server)
+stats_server_map(struct array *stats_server, const struct array *server)
 {
     rstatus_t status;
     uint32_t i, nserver;
@@ -233,7 +233,7 @@ stats_server_unmap(struct array *stats_server)
 }
 
 static rstatus_t
-stats_pool_init(struct stats_pool *stp, struct server_pool *sp)
+stats_pool_init(struct stats_pool *stp, const struct server_pool *sp)
 {
     rstatus_t status;
 
@@ -281,7 +281,7 @@ stats_pool_reset(struct array *stats_pool)
 }
 
 static rstatus_t
-stats_pool_map(struct array *stats_pool, struct array *server_pool)
+stats_pool_map(struct array *stats_pool, const struct array *server_pool)
 {
     rstatus_t status;
     uint32_t i, npool;
@@ -295,7 +295,7 @@ stats_pool_map(struct array *stats_pool, struct array *server_pool)
     }
 
     for (i = 0; i < npool; i++) {
-        struct server_pool *sp = array_get(server_pool, i);
+        const struct server_pool *sp = array_get(server_pool, i);
         struct stats_pool *stp = array_push(stats_pool);
 
         status = stats_pool_init(stp, sp);
@@ -432,7 +432,7 @@ stats_destroy_buf(struct stats *st)
 }
 
 static rstatus_t
-stats_add_string(struct stats *st, struct string *key, struct string *val)
+stats_add_string(struct stats *st, const struct string *key, const struct string *val)
 {
     struct stats_buffer *buf;
     uint8_t *pos;
@@ -455,7 +455,7 @@ stats_add_string(struct stats *st, struct string *key, struct string *val)
 }
 
 static rstatus_t
-stats_add_num(struct stats *st, struct string *key, int64_t val)
+stats_add_num(struct stats *st, const struct string *key, int64_t val)
 {
     struct stats_buffer *buf;
     uint8_t *pos;
@@ -551,7 +551,7 @@ stats_add_footer(struct stats *st)
 }
 
 static rstatus_t
-stats_begin_nesting(struct stats *st, struct string *key)
+stats_begin_nesting(struct stats *st, const struct string *key)
 {
     struct stats_buffer *buf;
     uint8_t *pos;
@@ -628,12 +628,13 @@ stats_copy_metric(struct stats *st, struct array *metric)
 }
 
 static void
-stats_aggregate_metric(struct array *dst, struct array *src)
+stats_aggregate_metric(struct array *dst, const struct array *src)
 {
     uint32_t i;
 
     for (i = 0; i < array_n(src); i++) {
-        struct stats_metric *stm1, *stm2;
+        const struct stats_metric *stm1;
+        struct stats_metric *stm2;
 
         stm1 = array_get(src, i);
         stm2 = array_get(dst, i);
@@ -888,7 +889,7 @@ stats_stop_aggregator(struct stats *st)
 
 struct stats *
 stats_create(uint16_t stats_port, const char *stats_ip, int stats_interval,
-             const char *source, struct array *server_pool)
+             const char *source, const struct array *server_pool)
 {
     rstatus_t status;
     struct stats *st;
@@ -1013,7 +1014,7 @@ stats_swap(struct stats *st)
 }
 
 static struct stats_metric *
-stats_pool_to_metric(struct context *ctx, struct server_pool *pool,
+stats_pool_to_metric(struct context *ctx, const struct server_pool *pool,
                      stats_pool_field_t fidx)
 {
     struct stats *st;
@@ -1036,7 +1037,7 @@ stats_pool_to_metric(struct context *ctx, struct server_pool *pool,
 }
 
 void
-_stats_pool_incr(struct context *ctx, struct server_pool *pool,
+_stats_pool_incr(struct context *ctx, const struct server_pool *pool,
                  stats_pool_field_t fidx)
 {
     struct stats_metric *stm;
@@ -1051,7 +1052,7 @@ _stats_pool_incr(struct context *ctx, struct server_pool *pool,
 }
 
 void
-_stats_pool_decr(struct context *ctx, struct server_pool *pool,
+_stats_pool_decr(struct context *ctx, const struct server_pool *pool,
                  stats_pool_field_t fidx)
 {
     struct stats_metric *stm;
@@ -1066,7 +1067,7 @@ _stats_pool_decr(struct context *ctx, struct server_pool *pool,
 }
 
 void
-_stats_pool_incr_by(struct context *ctx, struct server_pool *pool,
+_stats_pool_incr_by(struct context *ctx, const struct server_pool *pool,
                     stats_pool_field_t fidx, int64_t val)
 {
     struct stats_metric *stm;
@@ -1081,7 +1082,7 @@ _stats_pool_incr_by(struct context *ctx, struct server_pool *pool,
 }
 
 void
-_stats_pool_decr_by(struct context *ctx, struct server_pool *pool,
+_stats_pool_decr_by(struct context *ctx, const struct server_pool *pool,
                     stats_pool_field_t fidx, int64_t val)
 {
     struct stats_metric *stm;
@@ -1096,7 +1097,7 @@ _stats_pool_decr_by(struct context *ctx, struct server_pool *pool,
 }
 
 void
-_stats_pool_set_ts(struct context *ctx, struct server_pool *pool,
+_stats_pool_set_ts(struct context *ctx, const struct server_pool *pool,
                    stats_pool_field_t fidx, int64_t val)
 {
     struct stats_metric *stm;
@@ -1111,7 +1112,7 @@ _stats_pool_set_ts(struct context *ctx, struct server_pool *pool,
 }
 
 static struct stats_metric *
-stats_server_to_metric(struct context *ctx, struct server *server,
+stats_server_to_metric(struct context *ctx, const struct server *server,
                        stats_server_field_t fidx)
 {
     struct stats *st;
@@ -1137,7 +1138,7 @@ stats_server_to_metric(struct context *ctx, struct server *server,
 }
 
 void
-_stats_server_incr(struct context *ctx, struct server *server,
+_stats_server_incr(struct context *ctx, const struct server *server,
                    stats_server_field_t fidx)
 {
     struct stats_metric *stm;
@@ -1152,7 +1153,7 @@ _stats_server_incr(struct context *ctx, struct server *server,
 }
 
 void
-_stats_server_decr(struct context *ctx, struct server *server,
+_stats_server_decr(struct context *ctx, const struct server *server,
                    stats_server_field_t fidx)
 {
     struct stats_metric *stm;
@@ -1167,7 +1168,7 @@ _stats_server_decr(struct context *ctx, struct server *server,
 }
 
 void
-_stats_server_incr_by(struct context *ctx, struct server *server,
+_stats_server_incr_by(struct context *ctx, const struct server *server,
                       stats_server_field_t fidx, int64_t val)
 {
     struct stats_metric *stm;
@@ -1182,7 +1183,7 @@ _stats_server_incr_by(struct context *ctx, struct server *server,
 }
 
 void
-_stats_server_decr_by(struct context *ctx, struct server *server,
+_stats_server_decr_by(struct context *ctx, const struct server *server,
                       stats_server_field_t fidx, int64_t val)
 {
     struct stats_metric *stm;
@@ -1197,7 +1198,7 @@ _stats_server_decr_by(struct context *ctx, struct server *server,
 }
 
 void
-_stats_server_set_ts(struct context *ctx, struct server *server,
+_stats_server_set_ts(struct context *ctx, const struct server *server,
                      stats_server_field_t fidx, int64_t val)
 {
     struct stats_metric *stm;

--- a/src/nc_stats.h
+++ b/src/nc_stats.h
@@ -196,19 +196,19 @@ typedef enum stats_server_field {
 
 void stats_describe(void);
 
-void _stats_pool_incr(struct context *ctx, struct server_pool *pool, stats_pool_field_t fidx);
-void _stats_pool_decr(struct context *ctx, struct server_pool *pool, stats_pool_field_t fidx);
-void _stats_pool_incr_by(struct context *ctx, struct server_pool *pool, stats_pool_field_t fidx, int64_t val);
-void _stats_pool_decr_by(struct context *ctx, struct server_pool *pool, stats_pool_field_t fidx, int64_t val);
-void _stats_pool_set_ts(struct context *ctx, struct server_pool *pool, stats_pool_field_t fidx, int64_t val);
+void _stats_pool_incr(struct context *ctx, const struct server_pool *pool, stats_pool_field_t fidx);
+void _stats_pool_decr(struct context *ctx, const struct server_pool *pool, stats_pool_field_t fidx);
+void _stats_pool_incr_by(struct context *ctx, const struct server_pool *pool, stats_pool_field_t fidx, int64_t val);
+void _stats_pool_decr_by(struct context *ctx, const struct server_pool *pool, stats_pool_field_t fidx, int64_t val);
+void _stats_pool_set_ts(struct context *ctx, const struct server_pool *pool, stats_pool_field_t fidx, int64_t val);
 
-void _stats_server_incr(struct context *ctx, struct server *server, stats_server_field_t fidx);
-void _stats_server_decr(struct context *ctx, struct server *server, stats_server_field_t fidx);
-void _stats_server_incr_by(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
-void _stats_server_decr_by(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
-void _stats_server_set_ts(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
+void _stats_server_incr(struct context *ctx, const struct server *server, stats_server_field_t fidx);
+void _stats_server_decr(struct context *ctx, const struct server *server, stats_server_field_t fidx);
+void _stats_server_incr_by(struct context *ctx, const struct server *server, stats_server_field_t fidx, int64_t val);
+void _stats_server_decr_by(struct context *ctx, const struct server *server, stats_server_field_t fidx, int64_t val);
+void _stats_server_set_ts(struct context *ctx, const struct server *server, stats_server_field_t fidx, int64_t val);
 
-struct stats *stats_create(uint16_t stats_port, const char *stats_ip, int stats_interval, const char *source, struct array *server_pool);
+struct stats *stats_create(uint16_t stats_port, const char *stats_ip, int stats_interval, const char *source, const struct array *server_pool);
 void stats_destroy(struct stats *stats);
 void stats_swap(struct stats *stats);
 

--- a/src/nc_stats.h
+++ b/src/nc_stats.h
@@ -208,7 +208,7 @@ void _stats_server_incr_by(struct context *ctx, struct server *server, stats_ser
 void _stats_server_decr_by(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
 void _stats_server_set_ts(struct context *ctx, struct server *server, stats_server_field_t fidx, int64_t val);
 
-struct stats *stats_create(uint16_t stats_port, char *stats_ip, int stats_interval, char *source, struct array *server_pool);
+struct stats *stats_create(uint16_t stats_port, const char *stats_ip, int stats_interval, const char *source, struct array *server_pool);
 void stats_destroy(struct stats *stats);
 void stats_swap(struct stats *stats);
 

--- a/src/nc_string.c
+++ b/src/nc_string.c
@@ -61,7 +61,7 @@ string_empty(const struct string *str)
 {
     ASSERT((str->len == 0 && str->data == NULL) ||
            (str->len != 0 && str->data != NULL));
-    return str->len == 0 ? true : false;
+    return str->len == 0;
 }
 
 rstatus_t
@@ -108,10 +108,11 @@ string_compare(const struct string *s1, const struct string *s2)
     return nc_strncmp(s1->data, s2->data, s1->len);
 }
 
+static const char *const hex = "0123456789abcdef";
+
 static char *
 _safe_utoa(int _base, uint64_t val, char *buf)
 {
-    char hex[] = "0123456789abcdef";
     uint32_t base = (uint32_t) _base;
     *buf-- = 0;
     do {
@@ -123,7 +124,6 @@ _safe_utoa(int _base, uint64_t val, char *buf)
 static char *
 _safe_itoa(int base, int64_t val, char *buf)
 {
-    char hex[] = "0123456789abcdef";
     char *orig_buf = buf;
     const int32_t is_neg = (val < 0);
     *buf-- = 0;

--- a/src/nc_util.c
+++ b/src/nc_util.c
@@ -188,7 +188,7 @@ nc_get_rcvbuf(int sd)
 }
 
 int
-_nc_atoi(uint8_t *line, size_t n)
+_nc_atoi(const uint8_t *line, size_t n)
 {
     int value;
 
@@ -462,7 +462,7 @@ nc_msec_now(void)
 }
 
 static int
-nc_resolve_inet(struct string *name, int port, struct sockinfo *si)
+nc_resolve_inet(const struct string *name, int port, struct sockinfo *si)
 {
     int status;
     struct addrinfo *ai, *cai; /* head and current addrinfo */
@@ -532,7 +532,7 @@ nc_resolve_inet(struct string *name, int port, struct sockinfo *si)
 }
 
 static int
-nc_resolve_unix(struct string *name, struct sockinfo *si)
+nc_resolve_unix(const struct string *name, struct sockinfo *si)
 {
     struct sockaddr_un *un;
 
@@ -560,7 +560,7 @@ nc_resolve_unix(struct string *name, struct sockinfo *si)
  * This routine is reentrant
  */
 int
-nc_resolve(struct string *name, int port, struct sockinfo *si)
+nc_resolve(const struct string *name, int port, struct sockinfo *si)
 {
     if (name != NULL && name->data[0] == '/') {
         return nc_resolve_unix(name, si);
@@ -575,7 +575,7 @@ nc_resolve(struct string *name, int port, struct sockinfo *si)
  *
  * This routine is not reentrant
  */
-char *
+const char *
 nc_unresolve_addr(struct sockaddr *addr, socklen_t addrlen)
 {
     static char unresolve[NI_MAXHOST + NI_MAXSERV];
@@ -600,7 +600,7 @@ nc_unresolve_addr(struct sockaddr *addr, socklen_t addrlen)
  *
  * This routine is not reentrant
  */
-char *
+const char *
 nc_unresolve_peer_desc(int sd)
 {
     static struct sockinfo si;
@@ -626,7 +626,7 @@ nc_unresolve_peer_desc(int sd)
  *
  * This routine is not reentrant
  */
-char *
+const char *
 nc_unresolve_desc(int sd)
 {
     static struct sockinfo si;

--- a/src/nc_util.h
+++ b/src/nc_util.h
@@ -20,6 +20,18 @@
 
 #include <stdarg.h>
 
+#ifdef __GNUC__
+# define NC_GCC_VERSION (__GNUC__ * 1000 + __GNUC_MINOR__)
+#else
+# define NC_GCC_VERSION 0
+#endif
+#if NC_GCC_VERSION >= 2007
+#define NC_ATTRIBUTE_FORMAT(type, idx, first) __attribute__ ((format(type, idx, first)))
+#else
+#define NC_ATTRIBUTE_FORMAT(type, idx, first)
+#endif
+
+
 #define LF                  (uint8_t) 10
 #define CR                  (uint8_t) 13
 #define CRLF                "\x0d\x0a"
@@ -90,7 +102,7 @@ int nc_get_soerror(int sd);
 int nc_get_sndbuf(int sd);
 int nc_get_rcvbuf(int sd);
 
-int _nc_atoi(uint8_t *line, size_t n);
+int _nc_atoi(const uint8_t *line, size_t n);
 bool nc_valid_port(int n);
 
 /*
@@ -188,7 +200,7 @@ void nc_assert(const char *cond, const char *file, int line, int panic);
 void nc_stacktrace(int skip_count);
 void nc_stacktrace_fd(int fd);
 
-int _scnprintf(char *buf, size_t size, const char *fmt, ...);
+int _scnprintf(char *buf, size_t size, const char *fmt, ...) NC_ATTRIBUTE_FORMAT(printf, 3, 4);
 int _vscnprintf(char *buf, size_t size, const char *fmt, va_list args);
 int64_t nc_usec_now(void);
 int64_t nc_msec_now(void);
@@ -208,9 +220,9 @@ struct sockinfo {
     } addr;
 };
 
-int nc_resolve(struct string *name, int port, struct sockinfo *si);
-char *nc_unresolve_addr(struct sockaddr *addr, socklen_t addrlen);
-char *nc_unresolve_peer_desc(int sd);
-char *nc_unresolve_desc(int sd);
+int nc_resolve(const struct string *name, int port, struct sockinfo *si);
+const char *nc_unresolve_addr(struct sockaddr *addr, socklen_t addrlen);
+const char *nc_unresolve_peer_desc(int sd);
+const char *nc_unresolve_desc(int sd);
 
 #endif

--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -37,7 +37,7 @@
  * return false
  */
 static bool
-memcache_storage(struct msg *r)
+memcache_storage(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_MC_SET:
@@ -60,7 +60,7 @@ memcache_storage(struct msg *r)
  * return false
  */
 static bool
-memcache_cas(struct msg *r)
+memcache_cas(const struct msg *r)
 {
     if (r->type == MSG_REQ_MC_CAS) {
         return true;
@@ -74,7 +74,7 @@ memcache_cas(struct msg *r)
  * return false
  */
 static bool
-memcache_retrieval(struct msg *r)
+memcache_retrieval(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_MC_GET:
@@ -101,7 +101,7 @@ memcache_retrieval(struct msg *r)
  * so avoid them when possible.
  */
 static bool
-memcache_should_fragment(struct msg *r)
+memcache_should_fragment(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_MC_GET:
@@ -124,7 +124,7 @@ memcache_should_fragment(struct msg *r)
  * return false
  */
 static bool
-memcache_arithmetic(struct msg *r)
+memcache_arithmetic(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_MC_INCR:
@@ -143,7 +143,7 @@ memcache_arithmetic(struct msg *r)
  * return false
  */
 static bool
-memcache_delete(struct msg *r)
+memcache_delete(const struct msg *r)
 {
     if (r->type == MSG_REQ_MC_DELETE) {
         return true;
@@ -157,7 +157,7 @@ memcache_delete(struct msg *r)
  * return false
  */
 static bool
-memcache_touch(struct msg *r)
+memcache_touch(const struct msg *r)
 {
     if (r->type == MSG_REQ_MC_TOUCH) {
         return true;
@@ -1258,7 +1258,7 @@ memcache_append_key(struct msg *r, const uint8_t *key, uint32_t keylen)
     mbuf_copy(mbuf, key, keylen);
     r->mlen += keylen;
 
-    mbuf_copy(mbuf, (uint8_t *)" ", 1);
+    mbuf_copy(mbuf, (const uint8_t *)" ", 1);
     r->mlen += 1;
     return NC_OK;
 }

--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -1232,13 +1232,13 @@ error:
 }
 
 bool
-memcache_failure(struct msg *r)
+memcache_failure(const struct msg *r)
 {
     return false;
 }
 
 static rstatus_t
-memcache_append_key(struct msg *r, uint8_t *key, uint32_t keylen)
+memcache_append_key(struct msg *r, const uint8_t *key, uint32_t keylen)
 {
     struct mbuf *mbuf;
     struct keypos *kpos;

--- a/src/proto/nc_proto.h
+++ b/src/proto/nc_proto.h
@@ -144,7 +144,7 @@
 
 void memcache_parse_req(struct msg *r);
 void memcache_parse_rsp(struct msg *r);
-bool memcache_failure(struct msg *r);
+bool memcache_failure(const struct msg *r);
 void memcache_pre_coalesce(struct msg *r);
 void memcache_post_coalesce(struct msg *r);
 rstatus_t memcache_add_auth(struct context *ctx, struct conn *c_conn, struct conn *s_conn);
@@ -155,7 +155,7 @@ void memcache_swallow_msg(struct conn *conn, struct msg *pmsg, struct msg *msg);
 
 void redis_parse_req(struct msg *r);
 void redis_parse_rsp(struct msg *r);
-bool redis_failure(struct msg *r);
+bool redis_failure(const struct msg *r);
 void redis_pre_coalesce(struct msg *r);
 void redis_post_coalesce(struct msg *r);
 rstatus_t redis_add_auth(struct context *ctx, struct conn *c_conn, struct conn *s_conn);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -3127,7 +3127,7 @@ redis_handle_auth_req(struct msg *req, struct msg *rsp)
     key = kpos->start;
     keylen = (uint32_t)(kpos->end - kpos->start);
     valid = (keylen == pool->redis_auth.len) &&
-            (memcmp(pool->redis_auth.data, key, keylen) == 0) ? true : false;
+            (memcmp(pool->redis_auth.data, key, keylen) == 0);
     if (valid) {
         conn->authenticated = 1;
         return msg_append(rsp, rsp_ok.data, rsp_ok.len);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -2552,7 +2552,7 @@ error:
  * See issue: https://github.com/twitter/twemproxy/issues/369
  */
 bool
-redis_failure(struct msg *r)
+redis_failure(const struct msg *r)
 {
     ASSERT(!r->request);
 
@@ -2732,7 +2732,7 @@ redis_pre_coalesce(struct msg *r)
 }
 
 static rstatus_t
-redis_append_key(struct msg *r, uint8_t *key, uint32_t keylen)
+redis_append_key(struct msg *r, const uint8_t *key, uint32_t keylen)
 {
     uint32_t len;
     struct mbuf *mbuf;

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -40,7 +40,7 @@ static rstatus_t redis_handle_auth_req(struct msg *request, struct msg *response
  * return false
  */
 static bool
-redis_argz(struct msg *r)
+redis_argz(const struct msg *r)
 {
     switch (r->type) {
     /* TODO: PING has an optional argument, emulate that? */
@@ -61,7 +61,7 @@ redis_argz(struct msg *r)
  * return false
  */
 static bool
-redis_arg0(struct msg *r)
+redis_arg0(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_PERSIST:
@@ -103,7 +103,7 @@ redis_arg0(struct msg *r)
  * return false
  */
 static bool
-redis_arg1(struct msg *r)
+redis_arg1(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_EXPIRE:
@@ -146,7 +146,7 @@ redis_arg1(struct msg *r)
  * return false
  */
 static bool
-redis_arg2(struct msg *r)
+redis_arg2(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_GETRANGE:
@@ -186,7 +186,7 @@ redis_arg2(struct msg *r)
  * return false
  */
 static bool
-redis_arg3(struct msg *r)
+redis_arg3(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_LINSERT:
@@ -205,7 +205,7 @@ redis_arg3(struct msg *r)
  * return false
  */
 static bool
-redis_argn(struct msg *r)
+redis_argn(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_SORT:
@@ -297,7 +297,7 @@ redis_argn(struct msg *r)
  * more keys, otherwise return false
  */
 static bool
-redis_argx(struct msg *r)
+redis_argx(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_MGET:
@@ -318,7 +318,7 @@ redis_argx(struct msg *r)
  * more key-value pairs, otherwise return false
  */
 static bool
-redis_argkvx(struct msg *r)
+redis_argkvx(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_MSET:
@@ -338,7 +338,7 @@ redis_argkvx(struct msg *r)
  * that at least one argument is required, but that shouldn't be the case).
  */
 static bool
-redis_argeval(struct msg *r)
+redis_argeval(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_EVAL:
@@ -353,7 +353,7 @@ redis_argeval(struct msg *r)
 }
 
 static bool
-redis_nokey(struct msg *r)
+redis_nokey(const struct msg *r)
 {
     switch (r->type) {
     case MSG_REQ_REDIS_LOLWUT:
@@ -371,7 +371,7 @@ redis_nokey(struct msg *r)
  * string whose first character is '-', otherwise return false.
  */
 static bool
-redis_error(struct msg *r)
+redis_error(const struct msg *r)
 {
     switch (r->type) {
     case MSG_RSP_REDIS_ERROR:
@@ -3105,15 +3105,15 @@ static rstatus_t
 redis_handle_auth_req(struct msg *req, struct msg *rsp)
 {
     struct conn *conn = (struct conn *)rsp->owner;
-    struct server_pool *pool;
-    struct keypos *kpos;
-    uint8_t *key;
+    const struct server_pool *pool;
+    const struct keypos *kpos;
+    const uint8_t *key;
     uint32_t keylen;
     bool valid;
 
     ASSERT(conn->client && !conn->proxy);
 
-    pool = (struct server_pool *)conn->owner;
+    pool = (const struct server_pool *)conn->owner;
 
     if (!pool->require_auth) {
         /*

--- a/src/test_all.c
+++ b/src/test_all.c
@@ -47,7 +47,7 @@ static void test_hash_algorithms(void) {
 }
 
 static void test_config_parsing(void) {
-    char* conf_file = "../conf/nutcracker.yml";
+    const char* conf_file = "../conf/nutcracker.yml";
     struct conf * conf = conf_create(conf_file);
     if (conf == NULL) {
         printf("FAIL could not parse %s (this test should be run within src/ folder)\n", conf_file);

--- a/src/test_all.c
+++ b/src/test_all.c
@@ -60,7 +60,7 @@ static void test_config_parsing(void) {
     }
 }
 
-static void test_redis_parse_req_success_case(char* data, int expected_type) {
+static void test_redis_parse_req_success_case(const char* data, int expected_type) {
     struct conn fake_client = {0};
     struct mbuf *m = mbuf_get();
     const int SW_START = 0;  /* Same as SW_START in redis_parse_req */
@@ -71,7 +71,7 @@ static void test_redis_parse_req_success_case(char* data, int expected_type) {
     const size_t datalen = strlen(data);
 
     /* Copy data into the message */
-    mbuf_copy(m, (uint8_t*)data, datalen);
+    mbuf_copy(m, (const uint8_t*)data, datalen);
     /* Insert a single buffer into the message mbuf header */
     STAILQ_INIT(&req->mhdr);
     ASSERT(STAILQ_EMPTY(&req->mhdr));
@@ -104,7 +104,7 @@ static void test_redis_parse_req_success(void) {
     test_redis_parse_req_success_case("*1\r\n$4\r\nPING\r\n", MSG_REQ_REDIS_PING);
 }
 
-static void test_redis_parse_rsp_success_case(char* data) {
+static void test_redis_parse_rsp_success_case(const char* data, int expected) {
     int original_failures = failures;
     struct conn fake_client = {0};
     struct mbuf *m = mbuf_get();
@@ -116,7 +116,7 @@ static void test_redis_parse_rsp_success_case(char* data) {
     const size_t datalen = strlen(data);
 
     /* Copy data into the message */
-    mbuf_copy(m, (uint8_t*)data, datalen);
+    mbuf_copy(m, (const uint8_t*)data, datalen);
     /* Insert a single buffer into the message mbuf header */
     STAILQ_INIT(&rsp->mhdr);
     ASSERT(STAILQ_EMPTY(&rsp->mhdr));
@@ -126,6 +126,7 @@ static void test_redis_parse_rsp_success_case(char* data) {
     redis_parse_rsp(rsp);
     expect_same_ptr(m->last, rsp->pos, "redis_parse_rsp: expected rsp->pos to be m->last");
     expect_same_int(SW_START, rsp->state, "redis_parse_rsp: expected full buffer to be parsed");
+    expect_same_int(expected, rsp->type, "redis_parse_rsp: expected response type to be parsed");
     expect_same_uint32_t(1, rsp->rnarg ? rsp->rnarg : 1, "expected remaining args to be 0 or 1");
 
     msg_put(rsp);
@@ -137,17 +138,28 @@ static void test_redis_parse_rsp_success_case(char* data) {
 
 /* Test support for https://redis.io/topics/protocol */
 static void test_redis_parse_rsp_success(void) {
-    test_redis_parse_rsp_success_case("-CUSTOMERR\r\n");  /* Error message without a space */
-    test_redis_parse_rsp_success_case("-Error message\r\n");  /* Error message */
-    test_redis_parse_rsp_success_case("+OK\r\n");  /* Error message without a space */
-
-    test_redis_parse_rsp_success_case("$6\r\nfoobar\r\n");  /* bulk string */
-    test_redis_parse_rsp_success_case("$0\r\n\r\n");  /* empty bulk string */
-    test_redis_parse_rsp_success_case("$-1\r\n");  /* null value */
-    test_redis_parse_rsp_success_case("*0\r\n");  /* empty array */
-    test_redis_parse_rsp_success_case("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n");  /* array with 2 bulk strings */
-    test_redis_parse_rsp_success_case("*3\r\n:1\r\n:2\r\n:3\r\n");  /* array with 3 integers */
-    test_redis_parse_rsp_success_case("*-1\r\n");  /* null array for BLPOP */
+    /* Error message without a space */
+    test_redis_parse_rsp_success_case("-CUSTOMERR\r\n", MSG_RSP_REDIS_ERROR);
+    /* Error message */
+    test_redis_parse_rsp_success_case("-Error message\r\n", MSG_RSP_REDIS_ERROR);
+    /* Error message without a space */
+    test_redis_parse_rsp_success_case("+OK\r\n", MSG_RSP_REDIS_STATUS);
+    /* bulk string */
+    test_redis_parse_rsp_success_case("$6\r\nfoobar\r\n", MSG_RSP_REDIS_BULK);
+    /* empty bulk string */
+    test_redis_parse_rsp_success_case("$0\r\n\r\n", MSG_RSP_REDIS_BULK);
+    /* null value */
+    test_redis_parse_rsp_success_case("$-1\r\n", MSG_RSP_REDIS_BULK);
+    /* empty array */
+    test_redis_parse_rsp_success_case("*0\r\n", MSG_RSP_REDIS_MULTIBULK);
+    /* array with 2 bulk strings */
+    test_redis_parse_rsp_success_case("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
+            MSG_RSP_REDIS_MULTIBULK);
+    /* array with 3 integers */
+    test_redis_parse_rsp_success_case("*3\r\n:1\r\n:2\r\n:3\r\n",
+            MSG_RSP_REDIS_MULTIBULK);
+    /* null array for BLPOP */
+    test_redis_parse_rsp_success_case("*-1\r\n", MSG_RSP_REDIS_MULTIBULK);
     /*
      * Test support for parsing arrays of arrays.
      * They can be returned by COMMAND, EVAL, etc.
@@ -159,10 +171,10 @@ static void test_redis_parse_rsp_success(void) {
             ":3\r\n"
             "*2\r\n"
             "+Foo\r\n"
-            "-Bar\r\n");  /* array of 2 arrays */
+            "-Bar\r\n", MSG_RSP_REDIS_MULTIBULK);  /* array of 2 arrays */
 }
 
-static void test_memcache_parse_rsp_success_case(char* data, int expected) {
+static void test_memcache_parse_rsp_success_case(const char* data, int expected) {
     struct conn fake_client = {0};
     struct mbuf *m = mbuf_get();
     const int SW_START = 0;  /* Same as SW_START in memcache_parse_rsp */
@@ -173,7 +185,7 @@ static void test_memcache_parse_rsp_success_case(char* data, int expected) {
     const size_t datalen = strlen(data);
 
     /* Copy data into the message */
-    mbuf_copy(m, (uint8_t*)data, datalen);
+    mbuf_copy(m, (const uint8_t*)data, datalen);
     /* Insert a single buffer into the message mbuf header */
     STAILQ_INIT(&rsp->mhdr);
     ASSERT(STAILQ_EMPTY(&rsp->mhdr));
@@ -202,7 +214,7 @@ static void test_memcache_parse_rsp_success(void) {
     test_memcache_parse_rsp_success_case("VALUE key 0 2\r\nab\r\nVALUE key2 0 2\r\ncd\r\nEND\r\n", MSG_RSP_MC_END);
 }
 
-static void test_memcache_parse_req_success_case(char* data, int expected) {
+static void test_memcache_parse_req_success_case(const char* data, int expected) {
     struct conn fake_client = {0};
     struct mbuf *m = mbuf_get();
     const int SW_START = 0;  /* Same as SW_START in memcache_parse_req */
@@ -213,7 +225,7 @@ static void test_memcache_parse_req_success_case(char* data, int expected) {
     const size_t datalen = strlen(data);
 
     /* Copy data into the message */
-    mbuf_copy(m, (uint8_t*)data, datalen);
+    mbuf_copy(m, (const uint8_t*)data, datalen);
     /* Insert a single buffer into the message mbuf header */
     STAILQ_INIT(&req->mhdr);
     ASSERT(STAILQ_EMPTY(&req->mhdr));


### PR DESCRIPTION
Problem

Make it easier for readers to understand what arguments are or aren't modified by a function (etc.)
Make it harder to accidentally modify a pointer that is assumed to not be modified.

Solution

Add const qualifiers to function signatures, local variables, static variables
