### PR TITLE
Improve single-server pool efficiency, log event backend with version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
  2021-??-??  Tyson Andre
-    * twemproxy: version 0.4.2 release (dev)
+    * twemproxy: version 0.5.0 release (dev)
 	  Fix parsing of redis error response for error type with no space,
 	  add tests (tyson, tom dalton)
 	  Update integration tests, add C unit test suite for 'make check' (tyson)
@@ -23,6 +23,12 @@
 	  Upgrade from libyaml 0.1.4 to 0.2.5 (tyson)
 	  Fix compiler warnings about wrong conversion specifiers in format
 	  strings for logging (tyson)
+	  Log the async backend used and any debug options in the
+	  '--help'/'--version' output.
+	  Add support for many more new redis commands and updates to existing
+	  redis commands (tyson)
+	  Optimization: Skip hashing and choosing server index when a pool has
+	  exactly one server (tyson)
 
  2015-22-06  Manju Rajashekhar  <manj@cs.stanford.edu>
     * twemproxy: version 0.4.1 release

--- a/src/nc.c
+++ b/src/nc.c
@@ -551,7 +551,22 @@ main(int argc, char **argv)
     }
 
     if (show_version) {
-        log_stderr("This is nutcracker-%s" CRLF, NC_VERSION_STRING);
+        log_stderr("This is nutcracker-%s", NC_VERSION_STRING);
+#if NC_HAVE_EPOLL
+        log_stderr("async event backend: epoll");
+#elif NC_HAVE_KQUEUE
+        log_stderr("async event backend: kqueue");
+#elif NC_HAVE_EVENT_PORTS
+        log_stderr("async event backend: event_ports");
+#else
+        log_stderr("async event backend: unknown");
+#endif
+#if HAVE_ASSERT_PANIC || HAVE_ASSERT_LOG
+        log_stderr("debugging assertions are enabled (--enable-debug=yes|full), nutcracker may be less efficient");
+#endif
+        // Log a blank line after the version
+        log_stderr("");
+
         if (show_help) {
             nc_show_usage();
         }

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -647,9 +647,15 @@ uint32_t
 server_pool_idx(const struct server_pool *pool, const uint8_t *key, uint32_t keylen)
 {
     uint32_t hash, idx;
+    uint32_t nserver = array_n(&pool->server);
 
-    ASSERT(array_n(&pool->server) != 0);
+    ASSERT(nserver != 0);
     ASSERT(key != NULL);
+
+    if (nserver == 1) {
+        /* Optimization: Skip hashing and dispatching for pools with only one server */
+        return 0;
+    }
 
     /*
      * If hash_tag: is configured for this server pool, we use the part of


### PR DESCRIPTION
Improve efficiency when twemproxy is used as a proxy for a single server backend.
Make it easier for users to report which asynchronous event processing backend is used in bug reports.

Update changelog, indicate that 0.5.0 is the next release