### PR TITLE
Make error messages starting the stats server clearer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@
 	  exactly one server (tyson)
 	  Support memcache 'version' requests by proxying the request to a single
 	  backend memcache server to fetch the server version. (tyson)
+	  Make error messages for creating the stats server during startup clearer. (tyson)
 
  2015-22-06  Manju Rajashekhar  <manj@cs.stanford.edu>
     * twemproxy: version 0.4.1 release

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Twemproxy can be configured through a YAML file specified by the -c or --conf-fi
   + murmur
   + jenkins
 + **hash_tag**: A two character string that specifies the part of the key used for hashing. Eg "{}" or "$$". [Hash tag](notes/recommendation.md#hash-tags) enable mapping different keys to the same server as long as the part of the key within the tag is the same.
-+ **distribution**: The key distribution mode. Possible values are:
-  + ketama
-  + modula
-  + random
++ **distribution**: The key distribution mode for choosing backend servers based on the computed hash value. Possible values are:
+  + ketama (default, recommended. An implementation of https://en.wikipedia.org/wiki/Consistent_hashing)
+  + modula (use hash modulo number of servers to choose the backend)
+  + random (choose a random backend for each key of each request)
 + **timeout**: The timeout value in msec that we wait for to establish a connection to the server or receive a response from a server. By default, we wait indefinitely.
 + **backlog**: The TCP backlog argument. Defaults to 512.
 + **preconnect**: A boolean value that controls if twemproxy should preconnect to all the servers in this pool on process start. Defaults to false.

--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -831,24 +831,25 @@ stats_listen(struct stats *st)
 
     status = nc_set_reuseaddr(st->sd);
     if (status < 0) {
-        log_error("set reuseaddr on m %d failed: %s", st->sd, strerror(errno));
+        log_error("set reuseaddr on m %d failed for stats server: %s", st->sd, strerror(errno));
         return NC_ERROR;
     }
 
     status = bind(st->sd, (struct sockaddr *)&si.addr, si.addrlen);
     if (status < 0) {
-        log_error("bind on m %d to addr '%.*s:%u' failed: %s", st->sd,
+        log_error("bind on m %d to stats server addr '%.*s:%u' failed: %s", st->sd,
                   st->addr.len, st->addr.data, st->port, strerror(errno));
         return NC_ERROR;
     }
 
     status = listen(st->sd, SOMAXCONN);
     if (status < 0) {
-        log_error("listen on m %d failed: %s", st->sd, strerror(errno));
+        log_error("listen on m %d for stats server '%.*s:%u' failed: %s", st->sd,
+                  st->addr.len, st->addr.data, st->port, strerror(errno));
         return NC_ERROR;
     }
 
-    log_debug(LOG_NOTICE, "m %d listening on '%.*s:%u'", st->sd,
+    log_debug(LOG_NOTICE, "m %d listening on stats server '%.*s:%u'", st->sd,
               st->addr.len, st->addr.data, st->port);
 
     return NC_OK;

--- a/src/proto/nc_memcache.c
+++ b/src/proto/nc_memcache.c
@@ -1518,6 +1518,7 @@ memcache_copy_bulk(struct msg *dst, struct msg *src)
     for (; p < last && ('\r' != *p); p++) { /* eat cas for gets */
         ;
     }
+    /* "*p" should be pointing to '\r' */
 
     len += CRLF_LEN * 2;
     len += (p - mbuf->pos);


### PR DESCRIPTION
Closes #618

Problem

It isn't immediately obvious that some of the syslog messages are for listening on the stats server.

Solution

Mention that this is creating a stats server and the address used for listening in the issue message
