### PR TITLE
Update unit test for redis/memcache request testing

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,6 @@
-# Dockerfile to build nutcracker
-# ARGS: none
+# Dockerfile to create a slower debug build of nutcracker with assertions enabled
+# for continuous integration checks.
+# ARGS: REDIS_VER
 # Also see test_in_docker.sh
 FROM centos:7
 
@@ -37,8 +38,8 @@ RUN wget https://github.com/redis/redis/archive/$REDIS_VER.tar.gz && \
 	popd && \
 	rm -r redis-*
 
-# This will build and twemproxy 0.4.1 (with sflow)
-# Annoyingly, can't add multiple directories at once.
+# This will build twemproxy with compilation flags for running unit tests, integration tests.
+# Annoyingly, this can't add multiple directories at once.
 ADD conf /usr/src/twemproxy/conf
 ADD contrib /usr/src/twemproxy/contrib
 ADD man /usr/src/twemproxy/man

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 m4_define([NC_MAJOR], 0)
 m4_define([NC_MINOR], 4)
 m4_define([NC_PATCH], 1)
-m4_define([NC_BUGS], [manj@cs.stanford.edu])
+m4_define([NC_BUGS], [https://github.com/twitter/twemproxy/issues])
 
 # Initialize autoconf
 AC_PREREQ([2.64])


### PR DESCRIPTION
- Always clear errno before testing parsing.
- Update bug reporting address for `make check` to be the github issues url
- Migrate checks of parsing a lot of redis<= 3.2 commands to the C unit test