### PR TITLE
Release twemproxy 0.5.0-RC1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
- 2021-??-??  Tyson Andre
-    * twemproxy: version 0.5.0 release (dev)
+ 2021-06-07  Tyson Andre  <tysonandre775@hotmail.com>
+    * twemproxy: version 0.5.0-RC1 release
 	  Add 'tcpkeepalive' pool boolean config flag setting
 	  to enable tcp keepalive (charsyam, manju)
 	  Support redis bitpos command (clark kang)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## Build
 
-To build twemproxy from [distribution tarball](https://drive.google.com/open?id=0B6pVMMV5F5dfMUdJV25abllhUWM&authuser=0):
+To build twemproxy 0.5.0+ from [distribution tarball](https://github.com/twitter/twemproxy/releases):
 
     $ ./configure
     $ make
     $ sudo make install
 
-To build twemproxy from [distribution tarball](https://drive.google.com/open?id=0B6pVMMV5F5dfMUdJV25abllhUWM&authuser=0) in _debug mode_:
+To build twemproxy 0.5.0+ from [distribution tarball](https://github.com/twitter/twemproxy/releases) in _debug mode_:
 
     $ CFLAGS="-ggdb3 -O0" ./configure --enable-debug=full
     $ make
@@ -31,6 +31,13 @@ A quick checklist:
 + Use CFLAGS="-O1" ./configure && make
 + Use CFLAGS="-O3 -fno-strict-aliasing" ./configure && make
 + `autoreconf -fvi && ./configure` needs `automake` and `libtool` to be installed
+
+`make check` will run unit tests.
+
+### Older Releases
+
+Distribution tarballs for twemproxy <= 0.4.1 can be found at https://drive.google.com/open?id=0B6pVMMV5F5dfMUdJV25abllhUWM&authuser=0
+The build steps are the same (`./configure; make; sudo make install`).
 
 ## Features
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,12 +1,12 @@
 # Define the package version numbers and the bug reporting address
 m4_define([NC_MAJOR], 0)
-m4_define([NC_MINOR], 4)
-m4_define([NC_PATCH], 1)
+m4_define([NC_MINOR], 5)
+m4_define([NC_PATCH], 0)
 m4_define([NC_BUGS], [https://github.com/twitter/twemproxy/issues])
 
 # Initialize autoconf
 AC_PREREQ([2.64])
-AC_INIT([nutcracker], [NC_MAJOR.NC_MINOR.NC_PATCH], [NC_BUGS])
+AC_INIT([nutcracker], [NC_MAJOR.NC_MINOR.NC_PATCH-RC1], [NC_BUGS])
 AC_CONFIG_SRCDIR([src/nc.c])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_HEADERS([config.h:config.h.in])
@@ -19,7 +19,7 @@ AM_INIT_AUTOMAKE([1.9 foreign])
 AC_DEFINE(NC_VERSION_MAJOR, NC_MAJOR, [Define the major version number])
 AC_DEFINE(NC_VERSION_MINOR, NC_MINOR, [Define the minor version number])
 AC_DEFINE(NC_VERSION_PATCH, NC_PATCH, [Define the patch version number])
-AC_DEFINE(NC_VERSION_STRING, "NC_MAJOR.NC_MINOR.NC_PATCH", [Define the version string])
+AC_DEFINE(NC_VERSION_STRING, "NC_MAJOR.NC_MINOR.NC_PATCH-RC1", [Define the version string])
 
 # Checks for language
 AC_LANG([C])

--- a/scripts/nutcracker.spec
+++ b/scripts/nutcracker.spec
@@ -1,7 +1,7 @@
 Summary: Twitter's nutcracker redis and memcached proxy
 Name: nutcracker
-Version: 0.4.1
-Release: 1
+Version: 0.5.0
+Release: 0.1.rc1
 
 URL: https://github.com/twitter/twemproxy/
 Source0: %{name}-%{version}.tar.gz
@@ -66,6 +66,30 @@ fi
 %config(noreplace)%{_sysconfdir}/%{name}/%{name}.yml
 
 %changelog
+* Tue Jul 06 2021 Tyson Andre  <tysonandre775@hotmail.com>
+- twemproxy: version 0.5.0-RC1 release
+- Add 'tcpkeepalive' pool boolean config flag setting to enable tcp keepalive (charsyam, manju)
+- Support redis bitpos command (clark kang)
+- Fix parsing of redis error response for error type with no space, add tests (tyson, tom dalton)
+- Update integration tests, add C unit test suite for 'make check' (tyson)
+- Increase the maximum host length+port+identifier to 273 in ketama_update (李广博)
+- Always initialize file permissions field when listening on a unix domain socket (tyson)
+- Use number of servers instead of number of points on the continuum when sharding requests to backend services to improve sharding performance and fix potential invalid memory access when all hosts were ejected from a pool. (tyson)
+- Optimize performance of deletion of single redis keys (vincentve)
+- Don't fragment memcache/redis get commands when they only have a single key (improves performance and error handling of single key case) (tyson)
+- Don't let requests hang when there is a dns error when processing a fragmented request (e.g. multiget with multiple keys) (tyson)
+- Allow extra parameters for redis spop (charsyam)
+- Update documentation and README (various)
+- Fix memory leak bug for redis mset (deep011)
+- Support arbitrarily deep nested redis multi-bulk responses (nested arrays) (qingping209, tyson)
+- Upgrade from libyaml 0.1.4 to 0.2.5 (tyson)
+- Fix compiler warnings about wrong conversion specifiers in format strings for logging (tyson)
+- Log the async backend used and any debug options in the '--help'/'--version' output.
+- Add support for many more new redis commands and updates to existing redis commands (tyson)
+- Optimization: Skip hashing and choosing server index when a pool has exactly one server (tyson)
+- Support memcache 'version' requests by proxying the request to a single backend memcache server to fetch the server version. (tyson)
+- Make error messages for creating the stats server during startup clearer. (tyson)
+
 * Mon Jun 22 2015  Manju Rajashekhar  <manj@cs.stanford.edu>
 - twemproxy: version 0.4.1 release
 - backend server hostnames are resolved lazily
@@ -109,7 +133,7 @@ fi
 - support for set ex/px/nx/xx for redis 2.6.12 and up (ypocat)
 - kqueue (bsd) support (ferenyx)
 - fix parsing redis response to accept integer reply (charsyam)
-      
+
 * Tue Jul 30 2013 Tait Clarridge <tait@clarridge.ca>
 - Rebuild SPEC to work with CentOS
 - Added buildrequires if building with mock/koji


### PR DESCRIPTION
To be merged **Tuesday, July 6th or later** if no blockers are discovered.

- Distribution tarballs will be included with the release (To be generated with`autoreconf -fvi` on a fresh checkout)
- The release will be marked as pre-release
- Dates will be updated
- At least a week after 0.5.0-RC1 is out, create a release 0.5.0 marked as stable and update versions/dates