### PR TITLE
Add miscellaneous tests, fix compilation warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ AC_CHECK_FUNCS([dup2 gethostname gettimeofday strerror])
 AC_CHECK_FUNCS([socket])
 AC_CHECK_FUNCS([memchr memmove memset])
 AC_CHECK_FUNCS([strchr strndup strtoul])
+AC_CHECK_FUNCS([strdup])
 
 AC_CACHE_CHECK([if epoll works], [ac_cv_epoll_works],
   AC_TRY_RUN([

--- a/src/hashkit/nc_crc32.c
+++ b/src/hashkit/nc_crc32.c
@@ -111,7 +111,7 @@ hash_crc32(const char *key, size_t key_length)
 uint32_t
 hash_crc32a(const char *key, size_t key_length)
 {
-    const uint8_t *p = key;
+    const uint8_t *p = (const uint8_t *)key;
     uint32_t crc;
 
     crc = ~0U;

--- a/src/test_all.c
+++ b/src/test_all.c
@@ -42,6 +42,19 @@ static void test_hash_algorithms(void) {
     /* refer to libmemcached tests/hash_results.h */
     expect_same_uint32_t(2297466611U, hash_one_at_a_time("apple", 5), "should have expected one_at_a_time hash for key \"apple\"");
     expect_same_uint32_t(3195025439U, hash_md5("apple", 5), "should have expected md5 hash for key \"apple\"");
+
+    expect_same_uint32_t(3662830516U, hash_crc16("apple", 5), "should have expected crc16 hash for key \"apple\"");
+    expect_same_uint32_t(10542U,      hash_crc32("apple", 5), "should have expected crc32 hash for key \"apple\"");
+    expect_same_uint32_t(2838417488U, hash_crc32a("apple", 5), "should have expected crc32a hash for key \"apple\"");
+    expect_same_uint32_t(67176023U,   hash_fnv1_32("apple", 5), "should have expected fnv1_32 hash for key \"apple\"");
+    expect_same_uint32_t(280767167U,  hash_fnv1a_32("apple", 5), "should have expected fnv1a_32 hash for key \"apple\"");
+    expect_same_uint32_t(473199127U,  hash_fnv1_64("apple", 5), "should have expected fnv1_64 hash for key \"apple\"");
+    expect_same_uint32_t(1488911807U, hash_fnv1a_64("apple", 5), "should have expected fnv1a_64 hash for key \"apple\"");
+    expect_same_uint32_t(3738850110U, hash_hsieh("apple", 5), "should have expected hsieh hash for key \"apple\"");
+    expect_same_uint32_t(1442444624U, hash_jenkins("apple", 5), "should have expected jenkins hash for key \"apple\"");
+    expect_same_uint32_t(4142305122U, hash_murmur("apple", 5), "should have expected murmur hash for key \"apple\"");
+    /* The above have exactly the same result as libmemcached/tests/hash_results.h */
+
     expect_same_uint32_t(3853726576U, ketama_hash("server1-8", strlen("server1-8"), 0), "should have expected ketama_hash for server1-8 index 0");
     expect_same_uint32_t(2667054752U, ketama_hash("server1-8", strlen("server1-8"), 3), "should have expected ketama_hash for server1-8 index 3");
 }


### PR DESCRIPTION
Warn about `strdup` being missing during `configure` for libyaml.
(I was checking compatibility with older gcc and should have
used `-std=gnu99`, not `-std=c99`)

Avoid warning about pointer type casts and fallthrough.

Add tests of remaining supported hash functions being compatible with
libmemcached results.