### PR TITLE
fix parse eval on SW_ARG2 caclulate r->rlen error

### DIFF
--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1634,14 +1634,14 @@ redis_parse_req(struct msg *r)
             m = p + r->rlen;
             if (m >= b->last) {
                 /* 
-                 * For EVAL/EVALHASH, the r->token has been assigned a value.  
-                 * When m >= b->last happens will need to repair mbuf.  
+                 * For EVAL/EVALHASH, the r->token has been assigned a value.  When
+                 * m >= b->last happens will need to repair mbuf.  
                  * 
-                 * At the end of redis_parse_req, r->token will be used to choose the start (p) 
-                 * for the next call to redis_parse_req and 
-                 * clear r->token when repairing this and adding more data.
+                 * At the end of redis_parse_req, r->token will be used to choose
+                 * the start (p) for the next call to redis_parse_req and clear
+                 * r->token when repairing this and adding more data.
                  * 
-                 * So, only when r->token == NULL, we will need to calculate r->rlen again.
+                 * So, only when r->token == NULL we need to calculate r->rlen again.
                  */
                 if (r->token == NULL) {
                     r->rlen -= (uint32_t)(b->last - p);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1634,11 +1634,14 @@ redis_parse_req(struct msg *r)
             m = p + r->rlen;
             if (m >= b->last) {
                 /* 
-                 * For EVAL/EVALHASH, the r->token has been assigned a value. When 
-                 * m >= b->last happens we will need to repair mbuf. So, when r->token == NULL, 
-                 * we will need to calculate r->rlen again.
-                 *
-                 * At the end of redis_parse_req, r->token will be used to choose the start (p) for the next call to redis_parse_req and clear r->token when repairing this and adding more data.
+                 * For EVAL/EVALHASH, the r->token has been assigned a value.  
+                 * When m >= b->last happens will need to repair mbuf.  
+                 * 
+                 * At the end of redis_parse_req, r->token will be used to choose the start (p) 
+                 * for the next call to redis_parse_req and 
+                 * clear r->token when repairing this and adding more data.
+                 * 
+                 * So, only when r->token == NULL, we will need to calculate r->rlen again.
                  */
                 if (r->token == NULL) {
                     r->rlen -= (uint32_t)(b->last - p);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1633,11 +1633,14 @@ redis_parse_req(struct msg *r)
 
             m = p + r->rlen;
             if (m >= b->last) {
-                /* For EVAL/EVALHASH, the r->token has been assigned a value. When 
-                 * m > b->last will due to repair mbuf, so only r->token == NULL, 
-                 * need caculate r->rlen again. */
-                if (r->token == NULL)
-                {
+                /* 
+                 * For EVAL/EVALHASH, the r->token has been assigned a value. When 
+                 * m >= b->last happens we will need to repair mbuf. So, when r->token == NULL, 
+                 * we will need to calculate r->rlen again.
+                 *
+                 * At the end of redis_parse_req, r->token will be used to choose the start (p) for the next call to redis_parse_req and clear r->token when repairing this and adding more data.
+                 */
+                if (r->token == NULL) {
                     r->rlen -= (uint32_t)(b->last - p);
                 }
                 m = b->last - 1;

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1633,7 +1633,13 @@ redis_parse_req(struct msg *r)
 
             m = p + r->rlen;
             if (m >= b->last) {
-                r->rlen -= (uint32_t)(b->last - p);
+                /* For EVAL/EVALHASH, the r->token has been assigned a value. When 
+                 * m > b->last will due to repair mbuf, so only r->token == NULL, 
+                 * need caculate r->rlen again. */
+                if (r->token == NULL)
+                {
+                    r->rlen -= (uint32_t)(b->last - p);
+                }
                 m = b->last - 1;
                 p = m;
                 break;


### PR DESCRIPTION
Problem

This bug is very hidden and must be reproduced using carefully constructed commands.
The key point is：
* the command is eval
* first enter parse SW_ARG2 (m = p + r->rlen) >= b->last

eg(mbuf is 512):
    eval "return&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{KEYS[1],KEYS[2],ARGV[1],ARGV[2]}&nbsp;&nbsp;&nbsp;" 2 key1 first
![截图_选择区域_20210925230201](https://user-images.githubusercontent.com/241301/134776017-9b9f0a6f-2081-4f1b-9019-594d60adac91.png)

Solution
     When  m > b->last will due to repair mbuf, so only r->token == NULL, need caculate r->rlen again. 

Result
![截图_选择区域_20210925230303](https://user-images.githubusercontent.com/241301/134776039-c305f5cb-254f-4493-b970-edbfa5e7268a.png)


