### PR TITLE
Reduce one syscal for fcntl

### DIFF
--- a/src/nc_proxy.c
+++ b/src/nc_proxy.c
@@ -128,7 +128,7 @@ proxy_listen(struct context *ctx, struct conn *p)
 
     ASSERT(p->proxy);
 
-    p->sd = socket(p->family, SOCK_STREAM, 0);
+    p->sd = socket(p->family, SOCK_STREAM | SOCK_NONBLOCK, 0);
     if (p->sd < 0) {
         log_error("socket failed: %s", strerror(errno));
         return NC_ERROR;
@@ -162,13 +162,6 @@ proxy_listen(struct context *ctx, struct conn *p)
     status = listen(p->sd, pool->backlog);
     if (status < 0) {
         log_error("listen on p %d on addr '%.*s' failed: %s", p->sd,
-                  pool->addrstr.len, pool->addrstr.data, strerror(errno));
-        return NC_ERROR;
-    }
-
-    status = nc_set_nonblocking(p->sd);
-    if (status < 0) {
-        log_error("set nonblock on p %d on addr '%.*s' failed: %s", p->sd,
                   pool->addrstr.len, pool->addrstr.data, strerror(errno));
         return NC_ERROR;
     }

--- a/src/nc_server.c
+++ b/src/nc_server.c
@@ -483,19 +483,11 @@ server_connect(struct context *ctx, struct server *server, struct conn *conn)
     log_debug(LOG_VVERB, "connect to server '%.*s'", server->pname.len,
               server->pname.data);
 
-    conn->sd = socket(conn->family, SOCK_STREAM, 0);
+    conn->sd = socket(conn->family, SOCK_STREAM | SOCK_NONBLOCK, 0);
     if (conn->sd < 0) {
         log_error("socket for server '%.*s' failed: %s", server->pname.len,
                   server->pname.data, strerror(errno));
         status = NC_ERROR;
-        goto error;
-    }
-
-    status = nc_set_nonblocking(conn->sd);
-    if (status != NC_OK) {
-        log_error("set nonblock on s %d for server '%.*s' failed: %s",
-                  conn->sd, server->pname.len, server->pname.data,
-                  strerror(errno));
         goto error;
     }
 


### PR DESCRIPTION
According to the man page: https://man7.org/linux/man-pages/man2/socket.2.html
       Since Linux 2.6.27, the type argument serves a second purpose: in
       addition to specifying a socket type, it may include the bitwise
       OR of any of the following values, to modify the behavior of
       socket():

       SOCK_NONBLOCK
              Set the O_NONBLOCK file status flag on the open file
              description (see open(2)) referred to by the new file
              descriptor.  Using this flag saves extra calls to fcntl(2)
              to achieve the same result.

Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

Describe the modifications you've done.

Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.
